### PR TITLE
feat(enrollment): enrollment domain #14

### DIFF
--- a/enrollment/src/main/java/com/lxp/enrollment/domain/model/Enrollment.java
+++ b/enrollment/src/main/java/com/lxp/enrollment/domain/model/Enrollment.java
@@ -1,0 +1,70 @@
+package com.lxp.enrollment.domain.model;
+
+import com.lxp.enrollment.domain.model.enums.EnrollmentState;
+import com.lxp.enrollment.domain.model.vo.CourseId;
+import com.lxp.enrollment.domain.model.vo.EnrollmentDate;
+import com.lxp.enrollment.domain.model.vo.EnrollmentId;
+import com.lxp.enrollment.domain.model.vo.UserId;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class Enrollment {
+    private EnrollmentId enrollmentId;
+    private EnrollmentState state;
+    private UserId userId;
+    private CourseId courseId;
+    private EnrollmentDate enrollmentDate;
+
+    private Enrollment() {}
+
+    private Enrollment(EnrollmentState state, UserId userId, CourseId courseId) {
+        this.state = state;
+        this.userId = userId;
+        this.courseId = courseId;
+        this.enrollmentDate = new EnrollmentDate(LocalDateTime.now());
+    }
+
+    public static Enrollment create(UserId userId, CourseId courseId) {
+        Objects.requireNonNull(userId, "UserId must not be null");
+        Objects.requireNonNull(courseId, "CourseId must not be null");
+        return new Enrollment(EnrollmentState.ENROLLED, userId, courseId);
+    }
+
+    public void complete() {
+        if (this.state == EnrollmentState.CANCELLED) {
+            throw new IllegalStateException("취소된 수강은 완료할 수 없습니다.");
+        }
+        if (this.state == EnrollmentState.COMPLETED) {
+            return;
+        }
+
+        this.state = EnrollmentState.COMPLETED;
+    }
+
+    public void cancel(LocalDateTime now) {
+        Objects.requireNonNull(now, "now must not be null");
+
+        if (this.state == EnrollmentState.CANCELLED) {
+            return;
+        }
+
+        if (this.state == EnrollmentState.COMPLETED) {
+            throw new IllegalStateException("완료된 수강은 취소할 수 없습니다.");
+        }
+
+        if (!enrollmentDate.canCancel(now)) {
+            throw new IllegalStateException("수강 시작 후 3일이 지나 취소할 수 없습니다.");
+        }
+
+        this.state = EnrollmentState.CANCELLED;
+    }
+
+    public EnrollmentState state() {
+        return this.state;
+    }
+
+    public EnrollmentDate enrollmentDate() {
+        return this.enrollmentDate;
+    }
+}

--- a/enrollment/src/main/java/com/lxp/enrollment/domain/model/enums/EnrollmentState.java
+++ b/enrollment/src/main/java/com/lxp/enrollment/domain/model/enums/EnrollmentState.java
@@ -1,0 +1,7 @@
+package com.lxp.enrollment.domain.model.enums;
+
+public enum EnrollmentState {
+    ENROLLED,
+    COMPLETED,
+    CANCELLED
+}

--- a/enrollment/src/main/java/com/lxp/enrollment/domain/model/vo/CourseId.java
+++ b/enrollment/src/main/java/com/lxp/enrollment/domain/model/vo/CourseId.java
@@ -1,0 +1,9 @@
+package com.lxp.enrollment.domain.model.vo;
+
+public record CourseId(String value) {
+    public CourseId {
+        if (value != null && value.isEmpty()) {
+            throw new IllegalArgumentException("UserId must be not empty");
+        }
+    }
+}

--- a/enrollment/src/main/java/com/lxp/enrollment/domain/model/vo/EnrollmentDate.java
+++ b/enrollment/src/main/java/com/lxp/enrollment/domain/model/vo/EnrollmentDate.java
@@ -1,0 +1,18 @@
+package com.lxp.enrollment.domain.model.vo;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record EnrollmentDate(LocalDateTime value) {
+    private static final long CANCEL_LIMIT_DAYS = 3L;
+
+    public EnrollmentDate {
+        Objects.requireNonNull(value, "value is must not be null");
+    }
+
+    public boolean canCancel(LocalDateTime now) {
+        Objects.requireNonNull(now, "now is must not be null");
+        LocalDateTime deadline = value.plusDays(CANCEL_LIMIT_DAYS);
+        return !now.isAfter(deadline);
+    }
+}

--- a/enrollment/src/main/java/com/lxp/enrollment/domain/model/vo/EnrollmentId.java
+++ b/enrollment/src/main/java/com/lxp/enrollment/domain/model/vo/EnrollmentId.java
@@ -1,0 +1,10 @@
+package com.lxp.enrollment.domain.model.vo;
+
+public record EnrollmentId(Long value) {
+
+    public EnrollmentId {
+        if (value != null && value <= 0) {
+            throw new IllegalArgumentException("EnrollmentId must be positive when assigned");
+        }
+    }
+}

--- a/enrollment/src/main/java/com/lxp/enrollment/domain/model/vo/UserId.java
+++ b/enrollment/src/main/java/com/lxp/enrollment/domain/model/vo/UserId.java
@@ -1,0 +1,9 @@
+package com.lxp.enrollment.domain.model.vo;
+
+public record UserId(String value) {
+    public UserId {
+        if (value != null && value.isEmpty()) {
+            throw new IllegalArgumentException("UserId must be not empty");
+        }
+    }
+}

--- a/enrollment/src/test/java/com/lxp/enrollment/domain/model/EnrollmentTest.java
+++ b/enrollment/src/test/java/com/lxp/enrollment/domain/model/EnrollmentTest.java
@@ -1,0 +1,179 @@
+package com.lxp.enrollment.domain.model;
+
+import com.lxp.enrollment.domain.model.enums.EnrollmentState;
+import com.lxp.enrollment.domain.model.vo.CourseId;
+import com.lxp.enrollment.domain.model.vo.UserId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnrollmentTest {
+    private UserId userId() {
+        return new UserId(UUID.randomUUID().toString());
+    }
+
+    private CourseId courseId() {
+        return new CourseId(UUID.randomUUID().toString());
+    }
+
+    @Test
+    @DisplayName("정상 생성시 초기 상태는 ENROLLED 이어야 한다")
+    void create_success_initialStateEnrolled() {
+        // given && when
+        Enrollment enrollment = Enrollment.create(userId(), courseId());
+
+        // then
+        assertEquals(EnrollmentState.ENROLLED, enrollment.state());
+    }
+
+    @Test
+    @DisplayName("UserId가 null 이면 NPE가 발생한다")
+    void create_fail_whenUserIdNull() {
+        // given
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> Enrollment.create(null, new CourseId(UUID.randomUUID().toString())));
+
+        // when
+        assertEquals("UserId must not be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("CourseId가 null 이면 NPE가 발생한다")
+    void create_fail_whenCourseIdNull() {
+        // given
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> Enrollment.create(userId(), null)
+        );
+
+        // when
+        assertEquals("CourseId must not be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("ENROLLED 상태에서 강의 완료시 COMPLETED로 변경되어야 한다")
+    void complete_success_fromEnrolledToCompleted() {
+        // given
+        Enrollment enrollment = Enrollment.create(
+                new UserId(UUID.randomUUID().toString()),
+                new CourseId(UUID.randomUUID().toString())
+        );
+
+        // when
+        enrollment.complete();
+
+        // then
+        assertEquals(EnrollmentState.COMPLETED, enrollment.state());
+    }
+
+    @Test
+    @DisplayName("이미 수강 완료된 상태에서 complete를 재호출해도 상태가 그대로 유지된다")
+    void complete_again_whenAlreadyComplete() {
+        // given
+        Enrollment enrollment = Enrollment.create(
+                new UserId(UUID.randomUUID().toString()),
+                new CourseId(UUID.randomUUID().toString())
+        );
+        enrollment.complete();
+
+        // when
+        enrollment.complete();
+
+        // then
+        assertEquals(EnrollmentState.COMPLETED, enrollment.state());
+    }
+
+    @Test
+    @DisplayName("CANCELED 상태에서 complete를 호출하면 예외가 발생한다")
+    void complete_fail_whenCanceled() {
+        // given
+        Enrollment enrollment = Enrollment.create(
+                new UserId(UUID.randomUUID().toString()),
+                new CourseId(UUID.randomUUID().toString())
+        );
+        enrollment.cancel(LocalDateTime.now());
+
+        // when
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                enrollment::complete
+        );
+
+        // then
+        assertEquals("취소된 수강은 완료할 수 없습니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("ENROLLED 상태에서 수강 시작 3일 이내에 취소하면 CANCELLED로 변경된다")
+    void cancel_success_with3Days() {
+        // given
+        Enrollment enrollment = Enrollment.create(userId(), courseId());
+        LocalDateTime cancelAt = enrollment.enrollmentDate().value().plusDays(3);
+
+        // when
+        enrollment.cancel(cancelAt);
+
+        // then
+        assertEquals(EnrollmentState.CANCELLED, enrollment.state());
+    }
+
+    @Test
+    @DisplayName("cancel()에 now 파라니터가 null로 전달되면 NPE가 발생한다")
+    void cancel_fail_whenNonNow() {
+        // given
+        Enrollment enrollment = Enrollment.create(userId(), courseId());
+
+        // when
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> enrollment.cancel(null));
+
+        // then
+        assertEquals("now must not be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("이미 취소된 상태에서 cancel()을 호출하면 취소 상태가 그대로 유지된다")
+    void cancel_again_whenAlreadyCancelled() {
+        // given
+        Enrollment enrollment = Enrollment.create(userId(), courseId());
+        enrollment.cancel(LocalDateTime.now());
+
+        // when
+        enrollment.cancel(LocalDateTime.now().plusDays(1));
+
+        // then
+        assertEquals(EnrollmentState.CANCELLED, enrollment.state());
+    }
+
+    @Test
+    @DisplayName("COMPLETED 상태에서 cancel()을 호출하면 예외가 발생한다")
+    void cancel_fail_whenCompleted() {
+        // given
+        Enrollment enrollment = Enrollment.create(userId(), courseId());
+        enrollment.complete();
+
+        // when
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> enrollment.cancel(LocalDateTime.now()));
+
+        // then
+        assertEquals("완료된 수강은 취소할 수 없습니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("수강 시작 후 3일이 지나면 취소할 수 없다")
+    void cancel_fail_after3Days() {
+        // given
+        Enrollment enrollment = Enrollment.create(userId(), courseId());
+        LocalDateTime cancelAt = enrollment.enrollmentDate().value().plusDays(4);
+
+        // when
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> enrollment.cancel(cancelAt));
+
+        // then
+        assertEquals("수강 시작 후 3일이 지나 취소할 수 없습니다.", exception.getMessage());
+    }
+}


### PR DESCRIPTION
##  Summary
- 수강 도메인 구현

##  Related Issue
- Issue Number: #14
- Closes #14

##  Changes
- 수강 도메인, vo, 상태값 추가
- 테스트 코드 추가

##  Discussion Topic
- 임의로 수강 신청 후 3일 이내에 취소하면 취소 가능하도록 했습니다 

##  Checklist
- [x] 로컬 테스트 완료
- [ ] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [ ] 브랜치 최신화(rebase) 및 충돌 없음
