### PR TITLE
feat(tag): add tag, tagCategory domain and test

### DIFF
--- a/tag/src/main/java/com/lxp/tag/domain/exception/TagErrorCode.java
+++ b/tag/src/main/java/com/lxp/tag/domain/exception/TagErrorCode.java
@@ -4,8 +4,6 @@ import com.lxp.common.domain.exception.ErrorCode;
 
 public enum TagErrorCode implements ErrorCode {
     INVALID_CHANGE_CATEGORY("TAG_001", "Invalid tag can not change category", "BAD_REQUEST"),
-    INVALID_ASSIGN_TAG("TAG_002", "Inactive category cannot be assigned tag", "BAD_REQUEST"),
-    FAIL_CREATE_TAG_IN_INVALID_CATEGORY("TAG_003", "Cannot create tag in invalid category", "BAD_REQUEST"),
     ;
 
     private final String code;

--- a/tag/src/main/java/com/lxp/tag/domain/exception/TagErrorCode.java
+++ b/tag/src/main/java/com/lxp/tag/domain/exception/TagErrorCode.java
@@ -1,0 +1,35 @@
+package com.lxp.tag.domain.exception;
+
+import com.lxp.common.domain.exception.ErrorCode;
+
+public enum TagErrorCode implements ErrorCode {
+    INVALID_CHANGE_CATEGORY("TAG_001", "Invalid tag can not change category", "BAD_REQUEST"),
+    INVALID_ASSIGN_TAG("TAG_002", "Inactive category cannot be assigned tag", "BAD_REQUEST"),
+    FAIL_CREATE_TAG_IN_INVALID_CATEGORY("TAG_003", "Cannot create tag in invalid category", "BAD_REQUEST"),
+    ;
+
+    private final String code;
+    private final String message;
+    private final String group;
+
+    TagErrorCode(String code, String message, String group) {
+        this.code = code;
+        this.message = message;
+        this.group = group;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public String getGroup() {
+        return this.group;
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/domain/exception/TagException.java
+++ b/tag/src/main/java/com/lxp/tag/domain/exception/TagException.java
@@ -1,0 +1,18 @@
+package com.lxp.tag.domain.exception;
+
+import com.lxp.common.domain.exception.DomainException;
+import com.lxp.common.domain.exception.ErrorCode;
+
+public class TagException extends DomainException {
+    public TagException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    protected TagException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    protected TagException(ErrorCode errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/domain/model/Tag.java
+++ b/tag/src/main/java/com/lxp/tag/domain/model/Tag.java
@@ -17,6 +17,11 @@ public class Tag extends AggregateRoot {
 
     private Tag() {}
 
+    @Override
+    public Object getId() {
+        return this.tagId;
+    }
+
     private Tag(TagCategoryId tagCategoryId, String name, TagState state) {
         this.tagCategoryId = tagCategoryId;
         this.name = name;

--- a/tag/src/main/java/com/lxp/tag/domain/model/Tag.java
+++ b/tag/src/main/java/com/lxp/tag/domain/model/Tag.java
@@ -9,7 +9,7 @@ import com.lxp.tag.domain.model.vo.TagId;
 
 import java.util.Objects;
 
-public class Tag extends AggregateRoot {
+public class Tag extends AggregateRoot<TagId> {
     private TagId tagId;
     private TagCategoryId tagCategoryId;
     private String name;
@@ -18,7 +18,7 @@ public class Tag extends AggregateRoot {
     private Tag() {}
 
     @Override
-    public Object getId() {
+    public TagId getId() {
         return this.tagId;
     }
 

--- a/tag/src/main/java/com/lxp/tag/domain/model/Tag.java
+++ b/tag/src/main/java/com/lxp/tag/domain/model/Tag.java
@@ -1,0 +1,63 @@
+package com.lxp.tag.domain.model;
+
+import com.lxp.common.domain.event.AggregateRoot;
+import com.lxp.tag.domain.exception.TagErrorCode;
+import com.lxp.tag.domain.exception.TagException;
+import com.lxp.tag.domain.model.enums.TagState;
+import com.lxp.tag.domain.model.vo.TagCategoryId;
+import com.lxp.tag.domain.model.vo.TagId;
+
+import java.util.Objects;
+
+public class Tag extends AggregateRoot {
+    private TagId tagId;
+    private TagCategoryId tagCategoryId;
+    private String name;
+    private TagState state;
+
+    private Tag() {}
+
+    private Tag(TagCategoryId tagCategoryId, String name, TagState state) {
+        this.tagCategoryId = tagCategoryId;
+        this.name = name;
+        this.state = state;
+    }
+
+    public static Tag create(TagCategoryId tagCategoryId, String name) {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(tagCategoryId, "tagCategoryId must not be null");
+        return new Tag(tagCategoryId, name, TagState.ACTIVE);
+    }
+
+    public void changeCategory(TagCategoryId tagCategoryId) {
+        if (this.state == TagState.INACTIVE) {
+            throw new TagException(TagErrorCode.INVALID_CHANGE_CATEGORY);
+        }
+        this.tagCategoryId = tagCategoryId;
+    }
+
+    public void rename(String newName) {
+        Objects.requireNonNull(newName, "newName must not be null");
+        this.name = newName;
+    }
+
+    public void deactivate() {
+        this.state = TagState.INACTIVE;
+    }
+
+    public void activate() {
+        this.state = TagState.ACTIVE;
+    }
+
+    public TagCategoryId tagCategoryId() {
+        return this.tagCategoryId;
+    }
+
+    public String name() {
+        return this.name;
+    }
+
+    public boolean isActive() {
+        return this.state == TagState.ACTIVE;
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/domain/model/TagCategory.java
+++ b/tag/src/main/java/com/lxp/tag/domain/model/TagCategory.java
@@ -13,6 +13,11 @@ public class TagCategory extends AggregateRoot {
 
     private TagCategory() {}
 
+    @Override
+    public Object getId() {
+        return this.tagCategoryId;
+    }
+
     public TagCategory(String name, TagCategoryState state) {
         this.name = name;
         this.state = state;

--- a/tag/src/main/java/com/lxp/tag/domain/model/TagCategory.java
+++ b/tag/src/main/java/com/lxp/tag/domain/model/TagCategory.java
@@ -6,7 +6,7 @@ import com.lxp.tag.domain.model.vo.TagCategoryId;
 
 import java.util.Objects;
 
-public class TagCategory extends AggregateRoot {
+public class TagCategory extends AggregateRoot<TagCategoryId> {
     private TagCategoryId tagCategoryId;
     private String name;
     private TagCategoryState state;
@@ -14,7 +14,7 @@ public class TagCategory extends AggregateRoot {
     private TagCategory() {}
 
     @Override
-    public Object getId() {
+    public TagCategoryId getId() {
         return this.tagCategoryId;
     }
 

--- a/tag/src/main/java/com/lxp/tag/domain/model/TagCategory.java
+++ b/tag/src/main/java/com/lxp/tag/domain/model/TagCategory.java
@@ -1,0 +1,54 @@
+package com.lxp.tag.domain.model;
+
+import com.lxp.common.domain.event.AggregateRoot;
+import com.lxp.tag.domain.model.enums.TagCategoryState;
+import com.lxp.tag.domain.model.vo.TagCategoryId;
+
+import java.util.Objects;
+
+public class TagCategory extends AggregateRoot {
+    private TagCategoryId tagCategoryId;
+    private String name;
+    private TagCategoryState state;
+
+    private TagCategory() {}
+
+    public TagCategory(String name, TagCategoryState state) {
+        this.name = name;
+        this.state = state;
+    }
+
+    public static TagCategory create(String name) {
+        Objects.requireNonNull(name, "name must not be null");
+        return new TagCategory(name, TagCategoryState.ACTIVE);
+    }
+
+    public void reconstruct(TagCategoryId tagCategoryId) {
+        this.tagCategoryId = tagCategoryId;
+    }
+
+    public void rename(String newName) {
+        Objects.requireNonNull(newName, "newName must not be null");
+        this.name = newName;
+    }
+
+    public void deactivate() {
+        this.state = TagCategoryState.INACTIVE;
+    }
+
+    public void activate() {
+        this.state = TagCategoryState.ACTIVE;
+    }
+
+    public TagCategoryId id() {
+        return tagCategoryId;
+    }
+
+    public String name() {
+        return this.name;
+    }
+
+    public boolean isActive() {
+        return this.state == TagCategoryState.ACTIVE;
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/domain/model/enums/TagCategoryState.java
+++ b/tag/src/main/java/com/lxp/tag/domain/model/enums/TagCategoryState.java
@@ -1,0 +1,6 @@
+package com.lxp.tag.domain.model.enums;
+
+public enum TagCategoryState {
+    ACTIVE,
+    INACTIVE
+}

--- a/tag/src/main/java/com/lxp/tag/domain/model/enums/TagState.java
+++ b/tag/src/main/java/com/lxp/tag/domain/model/enums/TagState.java
@@ -1,0 +1,6 @@
+package com.lxp.tag.domain.model.enums;
+
+public enum TagState {
+    ACTIVE,
+    INACTIVE
+}

--- a/tag/src/main/java/com/lxp/tag/domain/model/vo/TagCategoryId.java
+++ b/tag/src/main/java/com/lxp/tag/domain/model/vo/TagCategoryId.java
@@ -1,0 +1,10 @@
+package com.lxp.tag.domain.model.vo;
+
+public record TagCategoryId(Long value) {
+
+    public TagCategoryId {
+        if (value == null || value <= 0) {
+            throw new IllegalArgumentException("value must be positive when assigned");
+        }
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/domain/model/vo/TagId.java
+++ b/tag/src/main/java/com/lxp/tag/domain/model/vo/TagId.java
@@ -1,0 +1,10 @@
+package com.lxp.tag.domain.model.vo;
+
+public record TagId(Long value) {
+
+    public TagId {
+        if (value == null || value <= 0) {
+            throw new IllegalArgumentException("TagId must be positive when assigned");
+        }
+    }
+}

--- a/tag/src/test/java/com/lxp/tag/domain/model/TagCategoryTest.java
+++ b/tag/src/test/java/com/lxp/tag/domain/model/TagCategoryTest.java
@@ -1,0 +1,87 @@
+package com.lxp.tag.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TagCategoryTest {
+    @Test
+    @DisplayName("태그 카테고리 name으로 TagCategory를 생성할 수 있다")
+    void create_success_withName() {
+        // given
+        String name = "backend";
+
+        // when
+        TagCategory tagCategory = TagCategory.create(name);
+
+        // then
+        assertEquals("backend", tagCategory.name());
+        assertTrue(tagCategory.isActive());
+    }
+
+    @Test
+    @DisplayName("태그 카테고리 name이 null 이면 NPE가 발생한다")
+    void create_fail_withNullName() {
+        // given && when
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> TagCategory.create(null));
+
+        // then
+        assertEquals("name must not be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("태그 카테고리 name을 변경할 수 있다")
+    void changeName_success_withValidName() {
+        // given
+        TagCategory tagCategory = TagCategory.create("backend");
+
+        // when
+        tagCategory.rename("Backend");
+
+        // then
+        assertEquals("Backend", tagCategory.name());
+    }
+
+    @Test
+    @DisplayName("변경 할 name이 null 이면 NPE가 발생한다")
+    void changeName_fail_withNullName() {
+        // given
+        TagCategory tagCategory = TagCategory.create("java");
+
+        // when
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> tagCategory.rename(null));
+
+        // then
+        assertEquals("newName must not be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("ACTIVE 태그를 INACTIVE로 변경할 수 있다")
+    void changeInactive_success_withActiveState() {
+        // given
+        TagCategory tagCategory = TagCategory.create("java");
+
+        // when
+        tagCategory.deactivate();
+
+        // then
+        assertFalse(tagCategory.isActive());
+    }
+
+    @Test
+    @DisplayName("INACTIVE 태그를 ACTIVE로 변경할 수 있다")
+    void changeActive_success_withInactiveState() {
+        // given
+        TagCategory tagCategory = TagCategory.create("java");
+        tagCategory.deactivate();
+
+        // when
+        tagCategory.activate();
+
+        // then
+        assertTrue(tagCategory.isActive());
+    }
+}

--- a/tag/src/test/java/com/lxp/tag/domain/model/TagTest.java
+++ b/tag/src/test/java/com/lxp/tag/domain/model/TagTest.java
@@ -1,0 +1,113 @@
+package com.lxp.tag.domain.model;
+
+import com.lxp.tag.domain.exception.TagErrorCode;
+import com.lxp.tag.domain.exception.TagException;
+import com.lxp.tag.domain.model.vo.TagCategoryId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TagTest {
+
+    public Tag tag(String name) {
+        return Tag.create(new TagCategoryId(1L), "java");
+    }
+
+    @Test
+    @DisplayName("태그 name으로 Tag를 생성할 수 있다")
+    void create_success_withName() {
+        // given
+        String name = "java";
+
+        // when
+        Tag tag = tag(name);
+
+        // then
+        assertEquals("java", tag.name());
+        assertTrue(tag.isActive());
+    }
+
+    @Test
+    @DisplayName("태그 name이 null이면 NPE가 발생한다")
+    void create_fail_withNullName() {
+        // given && when
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> tag(null));
+
+        // then
+        assertEquals("name must not be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("태그의 상태가 INACTIVE이면 카테고리를 변경에 실패한다")
+    void changeCategory_fail_withInactiveTag() {
+        // given
+        Tag tag = tag("java");
+        tag.deactivate();
+
+        // when
+        TagException exception = assertThrows(TagException.class,
+                () -> tag.changeCategory(new TagCategoryId(1L)));
+
+        // then
+        assertEquals(TagErrorCode.INVALID_CHANGE_CATEGORY, exception.getErrorCode());
+        assertEquals("TAG_001", exception.getErrorCode().getCode());
+        assertEquals("Invalid tag can not change category", exception.getErrorCode().getMessage());
+    }
+
+    @Test
+    @DisplayName("태그 name을 변경할 수 있다")
+    void changeName_success_withValidName() {
+        // given
+        Tag tag = tag("java");
+
+        // when
+        tag.rename("language");
+
+        // then
+        assertEquals("language", tag.name());
+    }
+    
+    @Test
+    @DisplayName("변경 할 name이 null 이면 NPE가 발생한다")
+    void changeName_fail_withNullName() {
+        // given
+        Tag tag = tag("java");
+        
+        // when
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> tag.rename(null));
+        
+        // then
+        assertEquals("newName must not be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("ACTIVE 태그를 INACTIVE로 변경할 수 있다")
+    void changeInactive_success_withActiveState() {
+        // given
+        Tag tag = tag("java");
+
+        // when
+        tag.deactivate();
+
+        // then
+        assertFalse(tag.isActive());
+    }
+
+    @Test
+    @DisplayName("INACTIVE 태그를 ACTIVE로 변경할 수 있다")
+    void changeActive_success_withInactiveState() {
+        // given
+        Tag tag = tag("java");
+        tag.deactivate();
+
+        // when
+        tag.activate();
+
+        // then
+        assertTrue(tag.isActive());
+    }
+
+}

--- a/tag/src/test/java/com/lxp/tag/domain/model/TagTest.java
+++ b/tag/src/test/java/com/lxp/tag/domain/model/TagTest.java
@@ -31,9 +31,12 @@ class TagTest {
     @Test
     @DisplayName("태그 name이 null이면 NPE가 발생한다")
     void create_fail_withNullName() {
-        // given && when
+        // given
+        TagCategoryId tagCategoryId = new TagCategoryId(1L);
+        String name = null;
+        // when
         NullPointerException exception = assertThrows(NullPointerException.class,
-                () -> tag(null));
+                () -> Tag.create(tagCategoryId, null));
 
         // then
         assertEquals("name must not be null", exception.getMessage());


### PR DESCRIPTION
##  Summary
- Tag, TagCategory 도메인 클래스 및 테스트 코드 추가

##  Related Issue
- Closes #17 

##  Changes
- Tag와 TagCategory 도메인
- 테스트 코드
- Tag DomainException, ErrorCode

##  Discussion Topic
### 설계
- Tag와 TagCategory를 각각 별도의 Aggregate Root로 설계 했습니다.
- 처음에는 TagCategory가 Aggregate Root가 되고, 내부에 Tag 리스트를 포함하는 구조를 고려했으나 아래 세 가지 이유로 분리하는 것이 더 적절하다고 판단했습니다.

#### 1. 생명주기
- Tag는 항상 특정 TagCategory에 속하지만 TagCategory는 Tag 없이도 생성, 존재할 수 있습니다.

- 비즈니스 관점에서 카테고리가 삭제되면 해당 카테고리에 속한 태그도 함께 삭제 하는 것이 자연스럽지만
이는 수강과 수강률 처럼 같이 생성되고 같이 사라지는 강한 연결을 가진 생명 주기는 아니라고 보았습니다.
  - 수강이 존재하는 동안 반드시 수강률이 필요

- 태그-카테고리는 게시판 서비스에서 "카테고리-게시글", "게시글-댓글" 관계처럼 느슨한 편에 가깝습니다

- Tag를 TagCategory 내부 컬렉션으로 강하게 묶기보다 서로 연관은 있지만 독립적인 Aggregate Root로 두는 편이 자연스럽다고 판단했습니다.

#### 2. 조회
- 이벤트 스토밍에서 주로 '시스템 상태를 변경'하는 도메인 이벤트 중심으로 모델링을 진행합니다. 이때 조회는 상태를 변경하지 않고 이미 존재하는 상태를 읽어오기만 하므로 이벤트로 잘 드러나지 않습니다.

- 우리 서비스의 UI/UX 요구사항
  - 회원가입/강좌 생성 화면에서 사용자 편리성을 위해 카테고리를 탭으로 두어 각 탭 아래에 태그를 분류해 보여줌
  - 강좌 목록, 수강 목록 화면에서는 카테고리 정보 없이 태그 정보만 필요

- 카테고리와 해당 카테고리에 속한 태그 목록 조회는 도메인 계층에서 반드시 카테고리가 태그 리스트를 필드로 가져야만 할 정도의 강한 불변 조건이나 일관성을 제어하는 로직이 있는 것이 아닙니다

- 인프라스트럭쳐 계층의 쿼리로도 충분히 카테고리와 그 카테고리에 포함된 태그를 조회할 수 있습니다

#### 3. 확장성
- 현재 시트템에서는 Tag를 시스템이 직접 생성하며 활성/비활성, 카테고리 변경과 같은 정책은 아직 없습니다 (코드에는 작성되어 있음)

- 추후 다음과 같은 비즈니스 규칙이 추가될 수는 있습니다.
  - 비활성화된 카테고리에는 태그를 생성할 수 없다
  - 태그의 카테고리를 변경할 수 있다

- 위와 같이 새롭게 추가되는 비즈니스 규칙은 아래와 같이 도메인 서비스에서 TagCategory와 Tag를 조합하여 충분히 표현할 수 있다고 보았습니다.

``` java
@DomainService
public class CreateTagDomainService {
    public Tag create(TagCategory category, String name) {
        if (!category.isActive()) {
            throw new TagException(TagErrorCode.FAIL_CREATE_TAG_IN_INVALID_CATEGORY);
        }

        return Tag.create(category.id(), name);
    }
}
```
- 카테고리와 태그 간에 비즈니스 규칙이 생기더라도 반드시 TagCategory가 Aggregate Root가 되어 Tag 컬렉션을 포함해야만 해결되는 것은 아니며 TagCategory에 의해 Tag가 관리되어야만 하는 것은 아니라고 판단했습니다.

### 결론
- 위 이유로 현재 단계에서는 Tag와 TagCategory를 각각 독립적인 Aggregate Root로 유지하는 방향을 선택했습니다
- 태그는 검색과 추천 알고리즘의 판단을 위해 사용되는 값이지만 정말 우리 시스템의 핵심 관심사가 맞는지는 의문입니다. 지금까지 나온 정책으로는 도메인으로 관리하는게 맞을까 하는 의문도 듭니다.
- 의견이 있으시다면 언제든 공유 부탁드립니다!

##  Checklist
- [x] 로컬 테스트 완료
- [ ] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [x] 브랜치 최신화(rebase) 및 충돌 없음
