### PR TITLE
feat: fix course entity

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation project(':tag')
     implementation project(':user')
 
+
     implementation 'org.springframework.modulith:spring-modulith-starter-jpa:2.0.0'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -3,7 +3,11 @@ spring:
     compose:
       enabled: true
       file: "application/compose.yaml"
-
+  modulith:
+    events:
+      jdbc-schema-initialization:
+        enabled: true
+        platform: mysql
   jpa:
     hibernate:
       ddl-auto: update

--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,9 @@ subprojects {
         annotationProcessor 'org.projectlombok:lombok'
 
 
-        implementation 'com.github.Poten-Up-3rd-Project.common-lib:common-domain:v1.0.2'
-        implementation 'com.github.Poten-Up-3rd-Project.common-lib:common-application:v1.0.2'
-        implementation 'com.github.Poten-Up-3rd-Project.common-lib:common-infrastructure:v1.0.2'
+        implementation 'com.github.Poten-Up-3rd-Project.common-lib:common-domain:v1.0.3'
+        implementation 'com.github.Poten-Up-3rd-Project.common-lib:common-application:v1.0.3'
+        implementation 'com.github.Poten-Up-3rd-Project.common-lib:common-infrastructure:v1.0.3'
 
 
         implementation 'org.springframework.modulith:spring-modulith-starter-core:1.2.1'

--- a/content/build.gradle
+++ b/content/build.gradle
@@ -21,6 +21,7 @@ bootJar {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation project(':common')
 }
 

--- a/content/src/main/java/com/lxp/content/course/application/port/provided/dto/command/CourseCreateCommand.java
+++ b/content/src/main/java/com/lxp/content/course/application/port/provided/dto/command/CourseCreateCommand.java
@@ -1,0 +1,4 @@
+package com.lxp.content.course.application.port.provided.dto.command;
+
+public record CourseCreateCommand() {
+}

--- a/content/src/main/java/com/lxp/content/course/application/port/provided/dto/result/CourseResult.java
+++ b/content/src/main/java/com/lxp/content/course/application/port/provided/dto/result/CourseResult.java
@@ -1,6 +1,7 @@
 package com.lxp.content.course.application.port.provided.dto.result;
 
-import java.util.Set;
+import java.util.List;
+import java.util.Map;
 
 public record CourseResult(
         String courseUUID,
@@ -10,7 +11,7 @@ public record CourseResult(
         String thumbnailUrl,
         String description,
         String difficulty, // JUNIOR, MIDDLE, SENIOR, EXPERT
-        Set<Long> tagsIds
+        Map<Long,Integer> tags
 
 ) {
 }

--- a/content/src/main/java/com/lxp/content/course/application/port/provided/usecase/CourseCreateUseCase.java
+++ b/content/src/main/java/com/lxp/content/course/application/port/provided/usecase/CourseCreateUseCase.java
@@ -1,0 +1,8 @@
+package com.lxp.content.course.application.port.provided.usecase;
+
+import com.lxp.common.application.port.in.UseCase;
+import com.lxp.content.course.application.port.provided.dto.command.CourseCreateCommand;
+
+public interface CourseCreateUseCase extends UseCase<CourseCreateCommand,Long> {
+
+}

--- a/content/src/main/java/com/lxp/content/course/application/service/CourseCreateService.java
+++ b/content/src/main/java/com/lxp/content/course/application/service/CourseCreateService.java
@@ -1,0 +1,13 @@
+package com.lxp.content.course.application.service;
+
+import com.lxp.content.course.application.port.provided.dto.command.CourseCreateCommand;
+import com.lxp.content.course.application.port.provided.usecase.CourseCreateUseCase;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CourseCreateService implements CourseCreateUseCase {
+    @Override
+    public Long execute(CourseCreateCommand input) {
+        return 0L;
+    }
+}

--- a/content/src/main/java/com/lxp/content/course/domain/model/Course.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/Course.java
@@ -12,9 +12,10 @@ import com.lxp.content.course.domain.model.id.InstructorUUID;
 import com.lxp.content.course.domain.model.vo.duration.CourseDuration;
 import com.lxp.content.course.domain.model.vo.duration.LectureDuration;
 
+import java.time.Instant;
 import java.util.Objects;
 
-public class Course extends AggregateRoot {
+public class Course extends AggregateRoot<CourseUUID> {
     private Long id;
     private final CourseUUID uuid;
     private final InstructorUUID instructorUUID;
@@ -24,6 +25,8 @@ public class Course extends AggregateRoot {
     private CourseSections sections;
     private CourseDifficulty difficulty;
     private CourseTags tags;
+    private Instant createdAt;
+    private Instant updatedAt;
 
     private Course(
             Long id,
@@ -34,7 +37,9 @@ public class Course extends AggregateRoot {
             String description,
             CourseDifficulty difficulty,
             CourseSections sections,
-            CourseTags tags
+            CourseTags tags,
+            Instant createdAt,
+            Instant updatedAt
     ) {
         this.id = id;
         this.uuid = uuid;
@@ -45,6 +50,8 @@ public class Course extends AggregateRoot {
         this.difficulty = Objects.requireNonNull(difficulty);
         this.sections = Objects.requireNonNull(sections);
         this.tags = tags;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 
     public static Course create(
@@ -66,7 +73,9 @@ public class Course extends AggregateRoot {
                 description,
                 difficulty,
                 sections,
-                tags
+                tags,
+                null,
+                null
         );
     }
 
@@ -79,9 +88,23 @@ public class Course extends AggregateRoot {
             String description,
             CourseDifficulty difficulty,
             CourseSections sections,
-            CourseTags tags
+            CourseTags tags,
+            Instant createdAt,
+            Instant updatedAt
     ) {
-        return new Course(id, uuid, instructorUUID, thumbnailUrl, title, description, difficulty, sections, tags);
+        return new Course(
+                id,
+                uuid,
+                instructorUUID,
+                thumbnailUrl,
+                title,
+                description,
+                difficulty,
+                sections,
+                tags,
+                createdAt,
+                updatedAt
+                );
     }
 
     //setters
@@ -164,9 +187,15 @@ public class Course extends AggregateRoot {
     public CourseSections sections() { return sections; }
     public String thumbnailUrl() { return thumbnailUrl; }
     public InstructorUUID instructorUUID() { return instructorUUID; }
+    public Instant createdAt() { return createdAt; }
+    public Instant updatedAt() { return updatedAt; }
 
     public CourseDuration totalDuration() {
         return sections.totalDuration();
     }
 
+    @Override
+    public CourseUUID getId() {
+        return uuid;
+    }
 }

--- a/content/src/main/java/com/lxp/content/course/domain/model/Course.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/Course.java
@@ -9,6 +9,8 @@ import com.lxp.content.course.domain.model.id.CourseUUID;
 import com.lxp.content.course.domain.model.id.LectureUUID;
 import com.lxp.content.course.domain.model.id.SectionUUID;
 import com.lxp.content.course.domain.model.id.InstructorUUID;
+import com.lxp.content.course.domain.model.vo.CourseDescription;
+import com.lxp.content.course.domain.model.vo.CourseTitle;
 import com.lxp.content.course.domain.model.vo.duration.CourseDuration;
 import com.lxp.content.course.domain.model.vo.duration.LectureDuration;
 
@@ -16,12 +18,12 @@ import java.time.Instant;
 import java.util.Objects;
 
 public class Course extends AggregateRoot<CourseUUID> {
-    private Long id;
+    private final Long id;
     private final CourseUUID uuid;
     private final InstructorUUID instructorUUID;
     private String thumbnailUrl;
-    private String title;
-    private String description;
+    private CourseTitle title;
+    private CourseDescription description;
     private CourseSections sections;
     private CourseDifficulty difficulty;
     private CourseTags tags;
@@ -33,8 +35,8 @@ public class Course extends AggregateRoot<CourseUUID> {
             CourseUUID uuid,
             InstructorUUID instructorUUID,
             String thumbnailUrl,
-            String title,
-            String description,
+            CourseTitle title,
+            CourseDescription description,
             CourseDifficulty difficulty,
             CourseSections sections,
             CourseTags tags,
@@ -49,7 +51,7 @@ public class Course extends AggregateRoot<CourseUUID> {
         this.description = description;
         this.difficulty = Objects.requireNonNull(difficulty);
         this.sections = Objects.requireNonNull(sections);
-        this.tags = tags;
+        this.tags = Objects.requireNonNull(tags);
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -69,8 +71,8 @@ public class Course extends AggregateRoot<CourseUUID> {
                 uuid,
                 instructorUUID,
                 thumbnailUrl,
-                title,
-                description,
+                CourseTitle.of(title),
+                CourseDescription.of(description),
                 difficulty,
                 sections,
                 tags,
@@ -97,8 +99,8 @@ public class Course extends AggregateRoot<CourseUUID> {
                 uuid,
                 instructorUUID,
                 thumbnailUrl,
-                title,
-                description,
+                CourseTitle.of(title),
+                CourseDescription.of(description),
                 difficulty,
                 sections,
                 tags,
@@ -109,11 +111,11 @@ public class Course extends AggregateRoot<CourseUUID> {
 
     //setters
     public void rename(String title) {
-        this.title = Objects.requireNonNull(title,"title cannot be null");
+        this.title = CourseTitle.of(Objects.requireNonNull(title,"title cannot be null"));
     }
 
     public void changeDescription(String description) {
-        this.description = description;
+        this.description = CourseDescription.of(description);
     }
 
     public void changeDifficulty(CourseDifficulty difficulty) {
@@ -181,8 +183,8 @@ public class Course extends AggregateRoot<CourseUUID> {
 
     public CourseUUID uuid() { return uuid; }
     public Long id() { return id; }
-    public String title() { return title; }
-    public String description() { return description; }
+    public CourseTitle title() { return title; }
+    public CourseDescription description() { return description; }
     public CourseDifficulty difficulty() { return difficulty; }
     public CourseSections sections() { return sections; }
     public String thumbnailUrl() { return thumbnailUrl; }

--- a/content/src/main/java/com/lxp/content/course/domain/model/Lecture.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/Lecture.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 
 public class Lecture extends BaseEntity<LectureUUID> {
     private final LectureUUID uuid;
-    private Long id;
+    private final Long id;
     private String title;
     private LectureDuration duration;
     private int order;

--- a/content/src/main/java/com/lxp/content/course/domain/model/Lecture.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/Lecture.java
@@ -1,11 +1,12 @@
 package com.lxp.content.course.domain.model;
 
+import com.lxp.common.domain.model.BaseEntity;
 import com.lxp.content.course.domain.model.id.LectureUUID;
 import com.lxp.content.course.domain.model.vo.duration.LectureDuration;
 
 import java.util.Objects;
 
-public class Lecture {
+public class Lecture extends BaseEntity<LectureUUID> {
     private final LectureUUID uuid;
     private Long id;
     private String title;
@@ -72,4 +73,9 @@ public class Lecture {
     public LectureDuration duration() { return duration; }
     public int order() { return order; }
     public String videoUrl() { return videoUrl; }
+
+    @Override
+    public LectureUUID getId() {
+        return uuid;
+    }
 }

--- a/content/src/main/java/com/lxp/content/course/domain/model/Section.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/Section.java
@@ -1,5 +1,6 @@
 package com.lxp.content.course.domain.model;
 
+import com.lxp.common.domain.model.BaseEntity;
 import com.lxp.content.course.domain.model.collection.SectionLectures;
 import com.lxp.content.course.domain.model.id.LectureUUID;
 import com.lxp.content.course.domain.model.id.SectionUUID;
@@ -8,8 +9,8 @@ import com.lxp.content.course.domain.model.vo.duration.SectionDuration;
 
 import java.util.Objects;
 
-public class Section {
-    private Long id;
+public class Section extends BaseEntity<SectionUUID> {
+    private final Long id;
     private final SectionUUID uuid;
     private String title;
     private int order;
@@ -87,5 +88,10 @@ public class Section {
 
     public SectionDuration totalDuration() {
         return lectures.totalDuration();
+    }
+
+    @Override
+    public SectionUUID getId() {
+        return uuid;
     }
 }

--- a/content/src/main/java/com/lxp/content/course/domain/model/collection/CourseSections.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/collection/CourseSections.java
@@ -15,15 +15,13 @@ import java.util.function.Function;
 public record CourseSections(List<Section> values){
 
     public CourseSections {
+        if (values == null || values.isEmpty()) {
+            throw new IllegalArgumentException("Course must have at least one section.");
+        }
         List<Section> sorted = new ArrayList<>(values);
         sorted.sort(Comparator.comparingInt(Section::order));
         values = List.copyOf(sorted);
     }
-
-    public static CourseSections empty() {
-        return new CourseSections(List.of());
-    }
-
 
     public CourseSections addSection(SectionUUID uuid, String title) {
         validateDuplicateUUID(uuid);
@@ -35,6 +33,10 @@ public record CourseSections(List<Section> values){
     }
 
     public CourseSections removeSection(SectionUUID uuid) {
+        if (values.size() <= 1) {
+            throw new IllegalStateException("Cannot remove the last section. A course must have at least one section.");
+        }
+
         List<Section> newList = values.stream()
                 .filter(sec -> !sec.uuid().equals(uuid))
                 .toList();

--- a/content/src/main/java/com/lxp/content/course/domain/model/collection/CourseSections.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/collection/CourseSections.java
@@ -7,7 +7,9 @@ import com.lxp.content.course.domain.model.id.SectionUUID;
 import com.lxp.content.course.domain.model.vo.duration.CourseDuration;
 import com.lxp.content.course.domain.model.vo.duration.LectureDuration;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.function.Function;
 
 public record CourseSections(List<Section> values){

--- a/content/src/main/java/com/lxp/content/course/domain/model/collection/CourseTags.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/collection/CourseTags.java
@@ -7,13 +7,21 @@ import java.util.List;
 
 
 public record CourseTags(List<TagId> values) {
+    private static final int MIN_SIZE = 1;
+    private static final int MAX_SIZE = 5;
 
     public CourseTags {
         values = List.copyOf(values == null ? List.of() : values);
+
+        if (values.isEmpty() || values.size() > MAX_SIZE) {
+            throw new IllegalArgumentException(
+                    String.format("Tags count must be between %d and %d. Current: %d", MIN_SIZE, MAX_SIZE, values.size())
+            );
+        }
     }
 
-    public static CourseTags empty() {
-        return new CourseTags(List.of());
+    public static CourseTags of(List<TagId> tags) {
+        return new CourseTags(tags);
     }
 
     public CourseTags add(TagId tag) {

--- a/content/src/main/java/com/lxp/content/course/domain/model/collection/CourseTags.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/collection/CourseTags.java
@@ -2,29 +2,30 @@ package com.lxp.content.course.domain.model.collection;
 
 import com.lxp.content.course.domain.model.id.TagId;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
-public record CourseTags(Set<TagId> values) {
+
+public record CourseTags(List<TagId> values) {
 
     public CourseTags {
-        values = Set.copyOf(values == null ? Set.of() : values);
+        values = List.copyOf(values == null ? List.of() : values);
     }
 
     public static CourseTags empty() {
-        return new CourseTags(Set.of());
+        return new CourseTags(List.of());
     }
 
     public CourseTags add(TagId tag) {
-        Set<TagId> newSet = new HashSet<>(values);
-        newSet.add(tag);
-        return new CourseTags(newSet);
+        List<TagId> newList = new ArrayList<>(values);
+        newList.add(tag);
+        return new CourseTags(newList);
     }
 
     public CourseTags remove(TagId tag) {
-        Set<TagId> newSet = new HashSet<>(values);
-        newSet.remove(tag);
-        return new CourseTags(newSet);
+        List<TagId> newList = new ArrayList<>(values);
+        newList.remove(tag);
+        return new CourseTags(newList);
     }
 
     public boolean contains(TagId tagId) {

--- a/content/src/main/java/com/lxp/content/course/domain/model/collection/SectionLectures.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/collection/SectionLectures.java
@@ -5,7 +5,10 @@ import com.lxp.content.course.domain.model.id.LectureUUID;
 import com.lxp.content.course.domain.model.vo.duration.LectureDuration;
 import com.lxp.content.course.domain.model.vo.duration.SectionDuration;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 public record SectionLectures(List<Lecture> values)  {

--- a/content/src/main/java/com/lxp/content/course/domain/model/id/SectionUUID.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/id/SectionUUID.java
@@ -3,7 +3,7 @@ package com.lxp.content.course.domain.model.id;
 public record SectionUUID(String value) {
     public SectionUUID {
         if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("SectionId must be positive");
+            throw new IllegalArgumentException("SectionId must be not null");
         }
     }
 }

--- a/content/src/main/java/com/lxp/content/course/domain/model/vo/CourseDescription.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/vo/CourseDescription.java
@@ -1,0 +1,15 @@
+package com.lxp.content.course.domain.model.vo;
+
+public record CourseDescription(String value) {
+    private static final int MAX_LENGTH = 50;
+
+    public CourseDescription {
+        if (value.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("Description length must be between 0 and " + MAX_LENGTH);
+        }
+    }
+
+    public static CourseDescription of(String value) {
+        return new CourseDescription(value);
+    }
+}

--- a/content/src/main/java/com/lxp/content/course/domain/model/vo/CourseTitle.java
+++ b/content/src/main/java/com/lxp/content/course/domain/model/vo/CourseTitle.java
@@ -1,0 +1,18 @@
+package com.lxp.content.course.domain.model.vo;
+
+public record CourseTitle(String value) {
+    private static final int MAX_LENGTH = 20;
+
+    public CourseTitle {
+        if(value == null || value.isEmpty()) {
+            throw new IllegalArgumentException("Title must not be null or empty");
+        }
+        if (value.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("Title length must be between 0 and " + MAX_LENGTH);
+        }
+    }
+
+    public static CourseTitle of(String value) {
+        return new CourseTitle(value);
+    }
+}

--- a/content/src/main/java/com/lxp/content/course/infrastructure/persistence/entity/CourseJpaEntity.java
+++ b/content/src/main/java/com/lxp/content/course/infrastructure/persistence/entity/CourseJpaEntity.java
@@ -1,0 +1,9 @@
+package com.lxp.content.course.infrastructure.persistence.entity;
+
+import com.lxp.common.infrastructure.persistence.BaseVersionedJpaEntity;
+import jakarta.persistence.Entity;
+
+//감사제거
+@Entity
+public class CourseJpaEntity extends BaseVersionedJpaEntity {
+}

--- a/content/src/main/java/com/lxp/content/course/infrastructure/persistence/entity/LectureJapEntity.java
+++ b/content/src/main/java/com/lxp/content/course/infrastructure/persistence/entity/LectureJapEntity.java
@@ -1,0 +1,8 @@
+package com.lxp.content.course.infrastructure.persistence.entity;
+
+import com.lxp.common.infrastructure.persistence.BaseJpaEntity;
+import jakarta.persistence.Entity;
+
+@Entity
+public class LectureJapEntity extends BaseJpaEntity {
+}

--- a/content/src/main/java/com/lxp/content/course/infrastructure/persistence/entity/SectionJpaEntity.java
+++ b/content/src/main/java/com/lxp/content/course/infrastructure/persistence/entity/SectionJpaEntity.java
@@ -1,0 +1,9 @@
+package com.lxp.content.course.infrastructure.persistence.entity;
+
+import com.lxp.common.infrastructure.persistence.BaseJpaEntity;
+import jakarta.persistence.Entity;
+
+@Entity
+public class SectionJpaEntity extends BaseJpaEntity {
+
+}

--- a/content/src/main/java/com/lxp/content/course/interfaces/CourseController.java
+++ b/content/src/main/java/com/lxp/content/course/interfaces/CourseController.java
@@ -1,0 +1,5 @@
+package com.lxp.content.course.interfaces;
+
+
+public class CourseController {
+}

--- a/content/src/main/java/com/lxp/content/course/interfaces/dto/response/CourseResponse.java
+++ b/content/src/main/java/com/lxp/content/course/interfaces/dto/response/CourseResponse.java
@@ -1,0 +1,19 @@
+package com.lxp.content.course.interfaces.dto.response;
+
+import com.lxp.content.course.domain.model.enums.CourseDifficulty;
+
+import java.util.List;
+
+public record CourseResponse(
+        String id,
+        String title,
+        String description,
+        String instructorName,
+        CourseDifficulty level,
+        long durationInHours,
+        // TODO("추후 tagResponse로 정의 - name 필요")
+        List<Long> tags,
+        List<SectionResponse> section
+
+) {
+}

--- a/content/src/main/java/com/lxp/content/course/interfaces/dto/response/CourseSummaryResponse.java
+++ b/content/src/main/java/com/lxp/content/course/interfaces/dto/response/CourseSummaryResponse.java
@@ -1,0 +1,6 @@
+package com.lxp.content.course.interfaces.dto.response;
+
+public record CourseSummaryResponse(
+
+) {
+}

--- a/content/src/main/java/com/lxp/content/course/interfaces/dto/response/LectureResponse.java
+++ b/content/src/main/java/com/lxp/content/course/interfaces/dto/response/LectureResponse.java
@@ -1,0 +1,11 @@
+package com.lxp.content.course.interfaces.dto.response;
+
+public record LectureResponse(
+        String id,
+        String title,
+        String videoUrl,
+        int order,
+        long durationInSeconds
+
+) {
+}

--- a/content/src/main/java/com/lxp/content/course/interfaces/dto/response/SectionResponse.java
+++ b/content/src/main/java/com/lxp/content/course/interfaces/dto/response/SectionResponse.java
@@ -1,0 +1,12 @@
+package com.lxp.content.course.interfaces.dto.response;
+
+import java.util.List;
+
+public record SectionResponse(
+    String id,
+    String title,
+    long durationInSeconds,
+    int order,
+    List<LectureResponse> lectures
+) {
+}

--- a/content/src/main/java/com/lxp/content/course/interfaces/dto/reuqest/create/CourseCreateRequest.java
+++ b/content/src/main/java/com/lxp/content/course/interfaces/dto/reuqest/create/CourseCreateRequest.java
@@ -1,0 +1,17 @@
+package com.lxp.content.course.interfaces.dto.reuqest.create;
+
+import com.lxp.content.course.domain.model.enums.CourseDifficulty;
+
+import java.util.List;
+
+//TODO("valid 체크 ")
+public record CourseCreateRequest(
+    String title,
+    String description,
+    String instructorId,
+    String thumbnailUrl,
+    CourseDifficulty level,
+    List<Long> tags,
+    List<SectionCreateRequest> sections
+) {
+}

--- a/content/src/main/java/com/lxp/content/course/interfaces/dto/reuqest/create/LectureCreateRequest.java
+++ b/content/src/main/java/com/lxp/content/course/interfaces/dto/reuqest/create/LectureCreateRequest.java
@@ -1,0 +1,7 @@
+package com.lxp.content.course.interfaces.dto.reuqest.create;
+
+public record LectureCreateRequest(
+    String title,
+    String videoUrl
+) {
+}

--- a/content/src/main/java/com/lxp/content/course/interfaces/dto/reuqest/create/SectionCreateRequest.java
+++ b/content/src/main/java/com/lxp/content/course/interfaces/dto/reuqest/create/SectionCreateRequest.java
@@ -1,0 +1,9 @@
+package com.lxp.content.course.interfaces.dto.reuqest.create;
+
+import java.util.List;
+
+public record SectionCreateRequest(
+    String title,
+    List<LectureCreateRequest> lectures
+) {
+}

--- a/enrollment/src/main/java/com/lxp/enrollment/domain/model/CourseStudy.java
+++ b/enrollment/src/main/java/com/lxp/enrollment/domain/model/CourseStudy.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 /**
  * 강좌 진행률 도메인
  */
-public class CourseStudy extends AggregateRoot {
+public class CourseStudy extends AggregateRoot<CourseStudyId> {
 
     private CourseStudyId courseStudyId;
     private float totalProgress;
@@ -110,4 +110,8 @@ public class CourseStudy extends AggregateRoot {
         this.completedAt = completedAt;
     }
 
+    @Override
+    public CourseStudyId getId() {
+        return courseStudyId;
+    }
 }


### PR DESCRIPTION
- change aggregateRoot
- add jpa entity


##  Summary
- common-lib version update
- reuqest,response 정의 (valid 체크는 추후)
- courseTitle, courseDescription  불변식 추가 / courseSection, courseTags 불변식 조건 추가 
##  Changes
- aggregateRoot에 baseEntity 추가했습니다
 확인해보니 model 에 equals와 hash코드를 적용을 안한거 같아, baseEntity를 상속받아 필요한부분에 적용했습니다
 각 도메인 엔티티에 감사기능이 jpa 를 추가하면 들어갈텐데 이 부분이 생략되어 추가했습니다.
courseTag는 order 가 포함될거라 List로 수정하였습니다.

- factory 클래스 또는 도메인 서비스에서 courseSection을 생성하여 root에서 추가하는 방향이라 courseSection 과 courseTags안에서 불변식을 추가하였습니다. 
  * course를 생성할때 최소 1개 이상의 section이 필요하다.
  * course를 생성할때 tag는 1개이상 5개 이하가 필요하다


 재웅님 aggregateRoot사용한부분 수정했으니 확인 부탁드릴게요
 

##  Discussion Topic
- 의논하고싶은 주제

##  Checklist
- [x] 로컬 테스트 완료
- [x] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [x] 브랜치 최신화(rebase) 및 충돌 없음
