### PR TITLE
feat(user, auth): implement user and auth domain

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -17,6 +17,8 @@ repositories {
 }
 
 dependencies {
+    implementation project(':common')
+    implementation project(':user')
 
 }
 

--- a/auth/src/main/java/com/lxp/auth/domain/common/exception/AuthErrorCode.java
+++ b/auth/src/main/java/com/lxp/auth/domain/common/exception/AuthErrorCode.java
@@ -1,0 +1,56 @@
+package com.lxp.auth.domain.common.exception;
+
+import com.lxp.common.domain.exception.ErrorCode;
+
+public enum AuthErrorCode implements ErrorCode {
+
+    /**
+     * AUTH_001: 아이디 또는 비밀번호 불일치 (보안을 위해 모호하게 처리)
+     */
+    INVALID_CREDENTIALS("UNAUTHORIZED", "AUTH_001", "아이디 또는 비밀번호가 일치하지 않습니다."),
+
+    /**
+     * AUTH_002: 토큰 만료 또는 형식 오류
+     */
+    UNAUTHORIZED_ACCESS("UNAUTHORIZED", "AUTH_002", "유효하지 않거나 만료된 토큰입니다."),
+
+    /**
+     * AUTH_003: 권한 부족 (접근이 거부됨)
+     */
+    ACCESS_DENIED("FORBIDDEN", "AUTH_003", "해당 리소스에 접근할 권한이 없습니다."),
+
+    /**
+     * AUTH_004: 이미 사용 중인 사용자명/이메일
+     */
+    DUPLICATE_USER_ID("CONFLICT", "AUTH_004", "이미 사용 중인 사용자 ID입니다."),
+
+    /**
+     * AUTH_005: 필수 인증 정보 누락
+     */
+    MISSING_REQUIRED_FIELD("BAD_REQUEST", "AUTH_005", "필수 인증 정보(ID/PW)가 누락되었습니다.");
+
+    private final String group;
+    private final String code;
+    private final String message;
+
+    AuthErrorCode(String group, String code, String message) {
+        this.group = group;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public String getGroup() {
+        return this.group;
+    }
+}

--- a/auth/src/main/java/com/lxp/auth/domain/common/exception/AuthException.java
+++ b/auth/src/main/java/com/lxp/auth/domain/common/exception/AuthException.java
@@ -1,0 +1,18 @@
+package com.lxp.auth.domain.common.exception;
+
+import com.lxp.common.domain.exception.DomainException;
+
+public class AuthException extends DomainException {
+
+    public AuthException() {
+        super(AuthErrorCode.ACCESS_DENIED);
+    }
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuthException(AuthErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/auth/src/main/java/com/lxp/auth/domain/common/model/vo/UserId.java
+++ b/auth/src/main/java/com/lxp/auth/domain/common/model/vo/UserId.java
@@ -1,0 +1,40 @@
+package com.lxp.auth.domain.common.model.vo;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record UserId(UUID value) {
+
+    public UserId {
+        Objects.requireNonNull(value);
+    }
+
+    public static UserId create() {
+        return new UserId(UUID.randomUUID());
+    }
+
+    public static UserId of(UUID value) {
+        return new UserId(value);
+    }
+
+    public static UserId of(String value) {
+        return new UserId(UUID.fromString(value));
+    }
+
+    public boolean matches(UUID id) {
+        return this.value.equals(id);
+    }
+
+    public boolean matches(UserId userId) {
+        return this.equals(userId);
+    }
+
+    public boolean matches(String userId) {
+        return this.asString().equals(userId);
+    }
+
+    public String asString() {
+        return this.value.toString();
+    }
+
+}

--- a/auth/src/main/java/com/lxp/auth/domain/local/model/entity/LocalAuth.java
+++ b/auth/src/main/java/com/lxp/auth/domain/local/model/entity/LocalAuth.java
@@ -1,0 +1,82 @@
+package com.lxp.auth.domain.local.model.entity;
+
+import com.lxp.auth.domain.common.model.vo.UserId;
+import com.lxp.auth.domain.local.model.vo.HashedPassword;
+import com.lxp.common.domain.event.AggregateRoot;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+public class LocalAuth extends AggregateRoot<UserId> {
+
+    private UserId id;
+    private String loginIdentifier;
+    private HashedPassword hashedPassword;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime lastPasswordModifiedAt;
+
+    private LocalAuth(UserId id, String loginIdentifier, HashedPassword hashedPassword, OffsetDateTime createdAt, OffsetDateTime lastPasswordModifiedAt) {
+        this.id = Objects.requireNonNull(id);
+        this.loginIdentifier = Objects.requireNonNull(loginIdentifier);
+        this.hashedPassword = Objects.requireNonNull(hashedPassword);
+        this.createdAt = Objects.requireNonNull(createdAt);
+        this.lastPasswordModifiedAt = lastPasswordModifiedAt;
+    }
+
+    public static LocalAuth register(String loginIdentifier, HashedPassword hashedPassword) {
+        return new LocalAuth(UserId.create(), loginIdentifier, hashedPassword, OffsetDateTime.now(), null);
+    }
+
+    public static LocalAuth of(
+        UserId id,
+        String loginIdentifier,
+        HashedPassword passwordHash,
+        OffsetDateTime createdAt,
+        OffsetDateTime lastPasswordModifiedAt
+    ) {
+        return new LocalAuth(id, loginIdentifier, passwordHash, createdAt, lastPasswordModifiedAt);
+    }
+
+    public void updatePassword(final HashedPassword newHashedPassword) {
+        this.hashedPassword = Objects.requireNonNull(newHashedPassword, "비밀번호는 null일 수 없습니다.");
+        lastPasswordModifiedAt = OffsetDateTime.now();
+    }
+
+    public boolean matchesId(UserId id) {
+        return this.id.matches(id);
+    }
+
+    public boolean matchesId(String id) {
+        return this.id.matches(id);
+    }
+
+    public UserId userId() {
+        return this.id;
+    }
+
+    public String loginIdentifier() {
+        return this.loginIdentifier;
+    }
+
+    public HashedPassword hashedPassword() {
+        return this.hashedPassword;
+    }
+
+    public String hashedPasswordAsString() {
+        return this.hashedPassword.value();
+    }
+
+    public OffsetDateTime createdAt() {
+        return this.createdAt;
+    }
+
+    public OffsetDateTime lastPasswordModifiedAt() {
+        return this.lastPasswordModifiedAt;
+    }
+
+    @Override
+    public UserId getId() {
+        return this.id;
+    }
+
+}

--- a/auth/src/main/java/com/lxp/auth/domain/local/model/vo/HashedPassword.java
+++ b/auth/src/main/java/com/lxp/auth/domain/local/model/vo/HashedPassword.java
@@ -1,0 +1,13 @@
+package com.lxp.auth.domain.local.model.vo;
+
+import java.util.Objects;
+
+public record HashedPassword(String value) {
+
+    public HashedPassword {
+        if (Objects.isNull(value) || value.isBlank()) {
+            throw new IllegalArgumentException("HashedPassword value cannot be empty.");
+        }
+    }
+
+}

--- a/auth/src/main/java/com/lxp/auth/domain/local/policy/PasswordPolicy.java
+++ b/auth/src/main/java/com/lxp/auth/domain/local/policy/PasswordPolicy.java
@@ -1,0 +1,27 @@
+package com.lxp.auth.domain.local.policy;
+
+import com.lxp.auth.domain.local.model.vo.HashedPassword;
+
+/**
+ * 비밀번호의 정책을 결정합니다.
+ */
+public interface PasswordPolicy {
+
+    /**
+     * 비밀번호를 인코딩합니다.
+     *
+     * @param rawPassword
+     * @return hashedPassword
+     */
+    HashedPassword apply(String rawPassword);
+
+    /**
+     * 비밀번호가 동일한지 확인합니다.
+     *
+     * @param rawPassword
+     * @param hashedPassword
+     * @return 동일할 경우 true, 아닐 경우 false
+     */
+    boolean isMatch(String rawPassword, HashedPassword hashedPassword);
+
+}

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -21,6 +21,7 @@ bootJar {
 }
 
 dependencies {
+    implementation project(':common')
 
 }
 

--- a/user/src/main/java/com/lxp/user/domain/common/exception/UserErrorCode.java
+++ b/user/src/main/java/com/lxp/user/domain/common/exception/UserErrorCode.java
@@ -1,0 +1,38 @@
+package com.lxp.user.domain.common.exception;
+
+import com.lxp.common.domain.exception.ErrorCode;
+
+public enum UserErrorCode implements ErrorCode {
+    USER_NOT_FOUND("NOT_FOUND", "USER_001", "사용자 정보를 찾을 수 없습니다."),
+    ROLE_NOT_FOUND("NOT_FOUND", "USER_002", "사용자 역할을 찾을 수 없습니다. (유효하지 않은 Role 이름)"),
+
+    DUPLICATE_USERNAME("CONFLICT", "USER_003", "이미 존재하는 사용자 이름입니다."),
+    INVALID_EMAIL_FORMAT("BAD_REQUEST", "USER_004", "유효하지 않은 이메일 형식입니다."),
+
+    UNHANDLED_ERROR("INTERNAL_SERVER_ERROR", "USER_005", "사용자 처리 중 알 수 없는 서버 오류가 발생했습니다.");
+
+    private final String group;
+    private final String code;
+    private final String message;
+
+    UserErrorCode(String group, String code, String message) {
+        this.group = group;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public String getGroup() {
+        return this.group;
+    }
+}

--- a/user/src/main/java/com/lxp/user/domain/common/exception/UserErrorCode.java
+++ b/user/src/main/java/com/lxp/user/domain/common/exception/UserErrorCode.java
@@ -9,7 +9,9 @@ public enum UserErrorCode implements ErrorCode {
     DUPLICATE_USERNAME("CONFLICT", "USER_003", "이미 존재하는 사용자 이름입니다."),
     INVALID_EMAIL_FORMAT("BAD_REQUEST", "USER_004", "유효하지 않은 이메일 형식입니다."),
 
-    UNHANDLED_ERROR("INTERNAL_SERVER_ERROR", "USER_005", "사용자 처리 중 알 수 없는 서버 오류가 발생했습니다.");
+    UNHANDLED_ERROR("INTERNAL_SERVER_ERROR", "USER_005", "사용자 처리 중 알 수 없는 서버 오류가 발생했습니다."),
+
+    SIZE_CONSTRAINT_VIOLATION("BAD_REQUEST", "USER_006", "길이가 일치하지 않습니다.");
 
     private final String group;
     private final String code;

--- a/user/src/main/java/com/lxp/user/domain/common/exception/UserException.java
+++ b/user/src/main/java/com/lxp/user/domain/common/exception/UserException.java
@@ -8,4 +8,8 @@ public class UserException extends DomainException {
     protected UserException(ErrorCode errorCode) {
         super(errorCode);
     }
+
+    public UserException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
 }

--- a/user/src/main/java/com/lxp/user/domain/common/exception/UserException.java
+++ b/user/src/main/java/com/lxp/user/domain/common/exception/UserException.java
@@ -1,0 +1,11 @@
+package com.lxp.user.domain.common.exception;
+
+import com.lxp.common.domain.exception.DomainException;
+import com.lxp.common.domain.exception.ErrorCode;
+
+public class UserException extends DomainException {
+
+    protected UserException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/user/src/main/java/com/lxp/user/domain/common/model/vo/UserId.java
+++ b/user/src/main/java/com/lxp/user/domain/common/model/vo/UserId.java
@@ -1,0 +1,24 @@
+package com.lxp.user.domain.common.model.vo;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record UserId(UUID value) {
+
+    public UserId {
+        Objects.requireNonNull(value);
+    }
+
+    public static UserId create() {
+        return new UserId(UUID.randomUUID());
+    }
+
+    public static UserId of(UUID value) {
+        return new UserId(value);
+    }
+
+    public static UserId of(String value) {
+        return new UserId(UUID.fromString(value));
+    }
+
+}

--- a/user/src/main/java/com/lxp/user/domain/common/model/vo/UserId.java
+++ b/user/src/main/java/com/lxp/user/domain/common/model/vo/UserId.java
@@ -21,4 +21,8 @@ public record UserId(UUID value) {
         return new UserId(UUID.fromString(value));
     }
 
+    public String asString() {
+        return value.toString();
+    }
+
 }

--- a/user/src/main/java/com/lxp/user/domain/profile/exception/TagSizeConstraintViolationException.java
+++ b/user/src/main/java/com/lxp/user/domain/profile/exception/TagSizeConstraintViolationException.java
@@ -1,0 +1,11 @@
+package com.lxp.user.domain.profile.exception;
+
+import com.lxp.user.domain.common.exception.UserErrorCode;
+import com.lxp.user.domain.common.exception.UserException;
+
+public class TagSizeConstraintViolationException extends UserException {
+
+    public TagSizeConstraintViolationException(int min, int max) {
+        super(UserErrorCode.SIZE_CONSTRAINT_VIOLATION, "태그는 최소 " + min + "개, 최대 " + max + "개까지 입력해야 합니다.");
+    }
+}

--- a/user/src/main/java/com/lxp/user/domain/profile/model/entity/UserProfile.java
+++ b/user/src/main/java/com/lxp/user/domain/profile/model/entity/UserProfile.java
@@ -1,0 +1,64 @@
+package com.lxp.user.domain.profile.model.entity;
+
+import com.lxp.common.domain.event.AggregateRoot;
+import com.lxp.user.domain.common.model.vo.UserId;
+import com.lxp.user.domain.profile.model.vo.LearnerLevel;
+import com.lxp.user.domain.profile.model.vo.Tags;
+import com.lxp.user.domain.profile.model.vo.UserProfileId;
+
+import java.util.List;
+import java.util.Objects;
+
+public class UserProfile extends AggregateRoot<UserProfileId> {
+
+    private UserProfileId id;
+    private UserId userId;
+    private LearnerLevel level;
+    private Tags tags;
+    private String job;
+
+    private UserProfile(UserProfileId id, UserId userId, LearnerLevel level, Tags tags, String job) {
+        this.id = Objects.requireNonNull(id);
+        this.userId = Objects.requireNonNull(userId);
+        this.level = Objects.requireNonNull(level);
+        this.tags = Objects.requireNonNull(tags);
+        this.job = job;
+    }
+
+    //todo 추후 도메인 서비스에서 user가 활성화 상태인지 여부 체크
+    public static UserProfile create(UserProfileId id, UserId userId, LearnerLevel level, Tags tags, String job) {
+        return new UserProfile(id, userId, level, tags, job);
+    }
+
+    //todo 추후 도메인 서비스에서 user가 활성화 상태인지 여부 체크
+    public void update(LearnerLevel level, List<String> tags, String job) {
+        this.level = Objects.requireNonNull(level);
+        this.tags = this.tags.withTags(tags);
+        this.job = job;
+    }
+
+    public UserProfileId id() {
+        return this.id;
+    }
+
+    public UserId userId() {
+        return this.userId;
+    }
+
+    public LearnerLevel level() {
+        return this.level;
+    }
+
+    public Tags tags() {
+        return this.tags;
+    }
+
+    public String job() {
+        return this.job;
+    }
+
+    @Override
+    public UserProfileId getId() {
+        return this.id;
+    }
+}

--- a/user/src/main/java/com/lxp/user/domain/profile/model/vo/LearnerLevel.java
+++ b/user/src/main/java/com/lxp/user/domain/profile/model/vo/LearnerLevel.java
@@ -1,0 +1,24 @@
+package com.lxp.user.domain.profile.model.vo;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum LearnerLevel {
+
+    JUNIOR("주니어"),
+    MIDDLE("미들"),
+    SENIOR("시니어"),
+    EXPERT("익스퍼트");
+
+    private final String description;
+
+    LearnerLevel(String description) {
+        this.description = description;
+    }
+
+    public static Optional<LearnerLevel> fromString(String levelName) {
+        return Arrays.stream(LearnerLevel.values())
+            .filter(role -> role.name().equalsIgnoreCase(levelName))
+            .findFirst();
+    }
+}

--- a/user/src/main/java/com/lxp/user/domain/profile/model/vo/Tags.java
+++ b/user/src/main/java/com/lxp/user/domain/profile/model/vo/Tags.java
@@ -1,0 +1,20 @@
+package com.lxp.user.domain.profile.model.vo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public record Tags(List<String> values) {
+
+    public Tags {
+        if (Objects.isNull(values) || values.isEmpty()) {
+            values = Collections.emptyList();
+        }
+        values = List.copyOf(values);
+    }
+
+    public Tags withTags(List<String> newTags) {
+        return new Tags(newTags);
+    }
+
+}

--- a/user/src/main/java/com/lxp/user/domain/profile/model/vo/Tags.java
+++ b/user/src/main/java/com/lxp/user/domain/profile/model/vo/Tags.java
@@ -1,14 +1,23 @@
 package com.lxp.user.domain.profile.model.vo;
 
+import com.lxp.user.domain.profile.exception.TagSizeConstraintViolationException;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 public record Tags(List<String> values) {
 
+    private static final int MAX_SIZE = 5;
+    private static final int MIN_SIZE = 3;
+
     public Tags {
         if (Objects.isNull(values) || values.isEmpty()) {
             values = Collections.emptyList();
+        }
+
+        if (values.size() < MIN_SIZE || values.size() > MAX_SIZE) {
+            throw new TagSizeConstraintViolationException(MIN_SIZE, MAX_SIZE);
         }
         values = List.copyOf(values);
     }

--- a/user/src/main/java/com/lxp/user/domain/profile/model/vo/UserProfileId.java
+++ b/user/src/main/java/com/lxp/user/domain/profile/model/vo/UserProfileId.java
@@ -1,0 +1,18 @@
+package com.lxp.user.domain.profile.model.vo;
+
+import java.util.Objects;
+
+public record UserProfileId(Long id) {
+
+    public UserProfileId {
+        Objects.requireNonNull(id, "id is null");
+    }
+
+    public boolean matches(UserProfileId userProfileId) {
+        return this.id.equals(userProfileId.id);
+    }
+
+    public boolean matches(Long userProfileId) {
+        return this.id.equals(userProfileId);
+    }
+}

--- a/user/src/main/java/com/lxp/user/domain/user/model/entity/User.java
+++ b/user/src/main/java/com/lxp/user/domain/user/model/entity/User.java
@@ -21,28 +21,28 @@ public class User extends AggregateRoot<UserId> {
 
     private UserStatus userStatus;
 
-    private User(UserId id, UserName name, UserEmail email, UserRole userRole) {
+    private User(UserId id, UserName name, UserEmail email, UserRole userRole, UserStatus userStatus) {
         this.id = Objects.requireNonNull(id);
         this.name = Objects.requireNonNull(name);
         this.email = Objects.requireNonNull(email);
         this.role = Objects.requireNonNull(userRole);
-        this.userStatus = UserStatus.ACTIVE;
+        this.userStatus = userStatus;
     }
 
-    public static User of(UserId id, UserName name, UserEmail email, UserRole userRole) {
-        return new User(id, name, email, userRole);
+    public static User of(UserId id, UserName name, UserEmail email, UserRole userRole, UserStatus userStatus) {
+        return new User(id, name, email, userRole, userStatus);
     }
 
     public static User createLearner(UserId id, UserName name, UserEmail email) {
-        return new User(id, name, email, UserRole.LEARNER);
+        return new User(id, name, email, UserRole.LEARNER, UserStatus.ACTIVE);
     }
 
     public static User createInstructor(UserId id, UserName name, UserEmail email) {
-        return new User(id, name, email, UserRole.INSTRUCTOR);
+        return new User(id, name, email, UserRole.INSTRUCTOR, UserStatus.ACTIVE);
     }
 
     public static User createAdmin(UserId id, UserName name, UserEmail email) {
-        return new User(id, name, email, UserRole.ADMIN);
+        return new User(id, name, email, UserRole.ADMIN, UserStatus.ACTIVE);
     }
 
     public void updateName(UserName name) {

--- a/user/src/main/java/com/lxp/user/domain/user/model/entity/User.java
+++ b/user/src/main/java/com/lxp/user/domain/user/model/entity/User.java
@@ -1,0 +1,95 @@
+package com.lxp.user.domain.user.model.entity;
+
+import com.lxp.common.domain.event.AggregateRoot;
+import com.lxp.user.domain.common.model.vo.UserId;
+import com.lxp.user.domain.user.model.vo.UserEmail;
+import com.lxp.user.domain.user.model.vo.UserName;
+import com.lxp.user.domain.user.model.vo.UserRole;
+import com.lxp.user.domain.user.model.vo.UserStatus;
+
+import java.util.Objects;
+
+public class User extends AggregateRoot<UserId> {
+
+    private UserId id;
+
+    private UserName name;
+
+    private UserEmail email;
+
+    private UserRole role;
+
+    private UserStatus userStatus;
+
+    private User(UserId id, UserName name, UserEmail email, UserRole userRole) {
+        this.id = Objects.requireNonNull(id);
+        this.name = Objects.requireNonNull(name);
+        this.email = Objects.requireNonNull(email);
+        this.role = Objects.requireNonNull(userRole);
+        this.userStatus = UserStatus.ACTIVE;
+    }
+
+    public static User of(UserId id, UserName name, UserEmail email, UserRole userRole) {
+        return new User(id, name, email, userRole);
+    }
+
+    public static User createLearner(UserId id, UserName name, UserEmail email) {
+        return new User(id, name, email, UserRole.LEARNER);
+    }
+
+    public static User createInstructor(UserId id, UserName name, UserEmail email) {
+        return new User(id, name, email, UserRole.INSTRUCTOR);
+    }
+
+    public static User createAdmin(UserId id, UserName name, UserEmail email) {
+        return new User(id, name, email, UserRole.ADMIN);
+    }
+
+    public void updateName(UserName name) {
+        this.name = Objects.requireNonNull(name);
+    }
+
+    public void makeInstructor() {
+        if (this.role == UserRole.LEARNER && this.userStatus == UserStatus.ACTIVE) {
+            this.role = UserRole.INSTRUCTOR;
+        }
+    }
+
+    public boolean canManageOwnCourse() {
+        return this.role == UserRole.INSTRUCTOR || this.role == UserRole.ADMIN;
+    }
+
+    public boolean canManageAllCourses() {
+        return this.role == UserRole.ADMIN;
+    }
+
+    public void withdraw() {
+        this.userStatus = UserStatus.DELETED;
+    }
+
+    public UserId id() {
+        return this.id;
+    }
+
+    public String name() {
+        return this.name.value();
+    }
+
+    public String email() {
+        return this.email.value();
+    }
+
+    public UserRole role() {
+        return this.role;
+    }
+
+    public UserStatus userStatus() {
+        return this.userStatus;
+    }
+
+    @Override
+    public UserId getId() {
+        return this.id;
+    }
+
+}

--- a/user/src/main/java/com/lxp/user/domain/user/model/vo/UserEmail.java
+++ b/user/src/main/java/com/lxp/user/domain/user/model/vo/UserEmail.java
@@ -1,0 +1,22 @@
+package com.lxp.user.domain.user.model.vo;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import static java.util.Objects.isNull;
+
+public record UserEmail(String value) {
+
+    public UserEmail {
+        if (isNull(value) || !EMAIL_PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException(value);
+        }
+    }
+
+    public static UserEmail of(String value) {
+        return new UserEmail(value);
+    }
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[\\w._%+-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$");
+
+}

--- a/user/src/main/java/com/lxp/user/domain/user/model/vo/UserEmail.java
+++ b/user/src/main/java/com/lxp/user/domain/user/model/vo/UserEmail.java
@@ -7,6 +7,8 @@ import static java.util.Objects.isNull;
 
 public record UserEmail(String value) {
 
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[\\w._%+-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$");
+
     public UserEmail {
         if (isNull(value) || !EMAIL_PATTERN.matcher(value).matches()) {
             throw new IllegalArgumentException(value);
@@ -16,7 +18,5 @@ public record UserEmail(String value) {
     public static UserEmail of(String value) {
         return new UserEmail(value);
     }
-
-    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[\\w._%+-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$");
 
 }

--- a/user/src/main/java/com/lxp/user/domain/user/model/vo/UserName.java
+++ b/user/src/main/java/com/lxp/user/domain/user/model/vo/UserName.java
@@ -4,11 +4,13 @@ import java.util.Objects;
 
 public record UserName(String value) {
 
+    private static final int MAX_LENGTH = 5;
+
     public UserName {
         if (Objects.isNull(value) || value.isBlank()) {
             throw new IllegalArgumentException("사용자 이름은 필수입니다.");
         }
-        if (value.length() > 5) {
+        if (value.length() > MAX_LENGTH) {
             throw new IllegalArgumentException("사용자 이름은 5자를 초과할 수 없습니다.");
         }
     }

--- a/user/src/main/java/com/lxp/user/domain/user/model/vo/UserName.java
+++ b/user/src/main/java/com/lxp/user/domain/user/model/vo/UserName.java
@@ -1,0 +1,20 @@
+package com.lxp.user.domain.user.model.vo;
+
+import java.util.Objects;
+
+public record UserName(String value) {
+
+    public UserName {
+        if (Objects.isNull(value) || value.isBlank()) {
+            throw new IllegalArgumentException("사용자 이름은 필수입니다.");
+        }
+        if (value.length() > 5) {
+            throw new IllegalArgumentException("사용자 이름은 5자를 초과할 수 없습니다.");
+        }
+    }
+
+    public static UserName of(String value) {
+        return new UserName(value);
+    }
+
+}

--- a/user/src/main/java/com/lxp/user/domain/user/model/vo/UserRole.java
+++ b/user/src/main/java/com/lxp/user/domain/user/model/vo/UserRole.java
@@ -1,0 +1,25 @@
+package com.lxp.user.domain.user.model.vo;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum UserRole {
+
+    LEARNER("학습자"), INSTRUCTOR("강사"), ADMIN("관리자");
+
+    private final String description;
+
+    UserRole(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static Optional<UserRole> fromString(String roleName) {
+        return Arrays.stream(UserRole.values())
+            .filter(role -> role.name().equalsIgnoreCase(roleName))
+            .findFirst();
+    }
+}

--- a/user/src/main/java/com/lxp/user/domain/user/model/vo/UserStatus.java
+++ b/user/src/main/java/com/lxp/user/domain/user/model/vo/UserStatus.java
@@ -1,0 +1,26 @@
+package com.lxp.user.domain.user.model.vo;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum UserStatus {
+    ACTIVE,
+    DELETED;
+
+    public static Optional<UserStatus> fromString(String statusName) {
+        return Arrays.stream(UserStatus.values())
+            .filter(role -> role.name().equalsIgnoreCase(statusName))
+            .findFirst();
+    }
+
+    public boolean catTransitionTo(UserStatus other) {
+        return switch (this) {
+            case ACTIVE -> other == ACTIVE || other == DELETED;
+            case DELETED -> false;
+        };
+    }
+
+    public boolean isActive() {
+        return this == ACTIVE;
+    }
+}

--- a/user/src/main/resources/openapi-user.yml
+++ b/user/src/main/resources/openapi-user.yml
@@ -1,56 +1,174 @@
-openapi: 3.0.3
-info:
-  title: "User Module Stub"
-  version: 1.0.0
-  description: "사용자 모듈의 paths와 components 조각 명세 예시"
 paths:
-  /users:
-    post:
+  /users/my:
+    get:
       tags:
-        - User
-      summary: 새로운 사용자 계정 생성
+        - UserProfile
+      summary: 특정 사용자의 프로필 정보 조회
+      operationId: getUserProfile
+      security:
+        - bearerAuth: [ ] # 인증된 사용자만 접근 가능하도록 설정
+      description: |
+        **접근 조건:** 유효한 Bearer 토큰을 가진 인증된 사용자라면 누구나 특정 ID의 프로필을 조회할 수 있습니다. 
+        (단, 비즈니스 규칙에 따라 'public' 프로필만 허용될 수 있음)
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: 프로필 정보를 조회할 대상 사용자의 고유 ID
+      responses:
+        '200':
+          description: 프로필 정보 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfileResponse'
+        '401':
+          description: 인증 실패 (유효하지 않은 토큰)
+        '404':
+          description: UserProfile을 찾을 수 없음 (해당 ID의 사용자 또는 프로필이 없는 경우)
+
+    patch:
+      tags:
+        - UserProfile
+      summary: 사용자 프로필 정보 업데이트 (레벨, 태그, 직업)
+      operationId: updateUserProfile
+      security:
+        - bearerAuth: [ ]
+      description: |
+        **접근 조건:** 1. 요청 토큰이 유효해야 합니다.
+        2. 경로의 `{userId}`는 **요청 토큰의 인증된 사용자 ID**와 반드시 일치해야 합니다 (본인 프로필 수정).
+        3. 요청 본문에는 변경할 필드만 포함합니다 (예: 'tags'만 보낼 수 있음).
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: 프로필을 수정할 사용자 본인의 고유 ID
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserCreateRequest'
+              type: object
+              properties:
+                level:
+                  type: string
+                  description: 변경하고자 하는 새로운 학습자 레벨
+                  nullable: true # 부분 업데이트이므로 null 허용
+                  enum: [ "JUNIOR", "MIDDLE", "SENIOR", "EXPERT" ]
+                tags:
+                  type: array
+                  description: 사용자가 관심 있는 태그 목록 (전체 교체)
+                  nullable: true
+                  items:
+                    type: string
+                job:
+                  type: string
+                  description: 사용자의 직업 정보
+                  nullable: true
       responses:
-        '201':
-          description: 생성 성공
+        '200':
+          description: 프로필 업데이트 성공
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserResponse'
-  /users/{id}:
-    get:
+                $ref: '#/components/schemas/UserProfileResponse'
+        '403':
+          description: 권한 없음 (경로 ID와 토큰 ID 불일치)
+        '404':
+          description: UserProfile을 찾을 수 없음
+    delete:
       tags:
         - User
-      summary: ID로 사용자 정보 조회
+      summary: 회원 탈퇴 (사용자 계정 삭제/비활성화)
+      operationId: deleteUser
+      security:
+        - bearerAuth: [ ]
+      description: |
+        **접근 조건:** 
+        1. 요청 토큰이 유효해야 합니다.
+        2. 경로의 `{userId}`는 **요청 토큰의 인증된 사용자 ID**와 반드시 일치해야 합니다 (본인 탈퇴).
+        3. 실제 DB에서는 데이터를 영구 삭제하지 않고, '비활성화' 또는 '삭제됨' 상태로 변경하여 보존하는 것이 일반적입니다.
       parameters:
-        - name: id
+        - name: userId
           in: path
           required: true
           schema:
-            type: integer
-components:
-  schemas:
-    UserCreateRequest:
-      type: object
-      properties:
-        username:
+            type: string
+          description: 탈퇴할 사용자 본인의 고유 ID
+      responses:
+        '204':
+          description: 계정 삭제 성공 (응답 본문 없음)
+        '401':
+          description: 인증 실패 (유효하지 않은 토큰)
+        '403':
+          description: 권한 없음 (경로 ID와 토큰 ID 불일치)
+        '404':
+          description: 사용자를 찾을 수 없음
+
+  /users/my/role:
+    put: # 새로운 정보를 서버에 보낼 때 (로그인, 회원가입 등)
+      tags:
+        - User
+      summary: 사용자 role로 변경
+      operationId: promoteToInstructor
+      security:
+        - bearerAuth: [ ]
+      description: | # 엔드포인트 레벨에서 역할 제한을 다시 강조
+        **접근 조건:** 
+        1. 요청 토큰에 **'LEARNER'** 역할 권한이 필수적으로 필요합니다.
+        2. 경로의 `{userId}`는 **요청 토큰의 인증된 사용자 ID**와 반드시 일치해야 합니다.
+        3. 요청 본문의 `role` 값은 승격에 해당하는 **'INSTRUCTOR'**여야 합니다.
+      x-required-role: LEARNER
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: 역할을 승격할 대상 사용자의 고유 ID (인증된 사용자 본인의 ID여야 함)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                role:
+                  type: string
+                  description:
+                    변경하고자 하는 새로운 역할 (예: "INSTRUCTOR")
+                  enum: [ "LEARNER", "INSTRUCTOR" ]
+      responses:
+        '200':
+          description: 역할 변경 성공
+        '403':
+          description: 권한 없음 (요청 토큰의 ID와 경로의 ID가 불일치하거나, 이미 INSTRUCTOR인 경우 등)
+        '404':
+          description: 사용자를 찾을 수 없음
+
+
+schemas:
+  UserProfileResponse:
+    type: object
+    properties:
+      userId:
+        type: string
+        description: 사용자의 고유 ID
+      name:
+        type: string
+        description: 사용자의 이름
+      level:
+        type: string
+        description: 학습자 레벨
+      tags:
+        type: array
+        items:
           type: string
-          example: testuser1
-        password:
-          type: string
-          format: password
-    UserResponse:
-      type: object
-      properties:
-        userId:
-          type: integer
-          example: 101
-        username:
-          type: string
-        email:
-          type: string
+        description: 관심 태그 목록
+      job:
+        type: string
+        description: 직업

--- a/user/src/test/java/com/lxp/user/domain/user/model/entity/UserTest.java
+++ b/user/src/test/java/com/lxp/user/domain/user/model/entity/UserTest.java
@@ -1,0 +1,226 @@
+package com.lxp.user.domain.user.model.entity;
+
+import com.lxp.user.domain.common.model.vo.UserId;
+import com.lxp.user.domain.user.model.vo.UserEmail;
+import com.lxp.user.domain.user.model.vo.UserName;
+import com.lxp.user.domain.user.model.vo.UserRole;
+import com.lxp.user.domain.user.model.vo.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UserTest {
+    private UserId userId;
+    private UserName initialName;
+    private UserEmail userEmail;
+
+    @BeforeEach
+    void setUp() {
+        userId = UserId.create();
+        initialName = new UserName("test");
+        userEmail = new UserEmail("initial@example.com");
+    }
+
+    // --- 1. 생성자 및 팩토리 메서드 테스트 ---
+
+    @Test
+    @DisplayName("Learner 팩토리 메서드로 User 객체를 생성하고 초기 상태를 확인한다")
+    void createLearner_success() {
+        // when
+        User learner = User.createLearner(userId, initialName, userEmail);
+
+        // then
+        assertAll(
+            () -> assertNotNull(learner, "User 객체는 null이 아니어야 한다."),
+            () -> assertEquals(userId, learner.id(), "ID가 일치해야 한다."),
+            () -> assertEquals(initialName.value(), learner.name(), "이름이 일치해야 한다."),
+            () -> assertEquals(userEmail.value(), learner.email(), "이메일이 일치해야 한다."),
+            () -> assertEquals(UserRole.LEARNER, learner.role(), "역할은 LEARNER여야 한다."),
+            () -> assertEquals(UserStatus.ACTIVE, learner.userStatus(), "상태는 ACTIVE여야 한다.")
+        );
+    }
+
+    @Test
+    @DisplayName("Instructor 팩토리 메서드로 User 객체를 생성하고 초기 상태를 확인한다")
+    void createInstructor_success() {
+        // when
+        User instructor = User.createInstructor(userId, initialName, userEmail);
+
+        // then
+        assertAll(
+            () -> assertEquals(UserRole.INSTRUCTOR, instructor.role(), "역할은 INSTRUCTOR여야 한다."),
+            () -> assertEquals(UserStatus.ACTIVE, instructor.userStatus(), "상태는 ACTIVE여야 한다.")
+        );
+    }
+
+    @Test
+    @DisplayName("Admin 팩토리 메서드로 User 객체를 생성하고 초기 상태를 확인한다")
+    void createAdmin_success() {
+        // when
+        User admin = User.createAdmin(userId, initialName, userEmail);
+
+        // then
+        assertAll(
+            () -> assertEquals(UserRole.ADMIN, admin.role(), "역할은 ADMIN여야 한다."),
+            () -> assertEquals(UserStatus.ACTIVE, admin.userStatus(), "상태는 ACTIVE여야 한다.")
+        );
+    }
+
+    @Test
+    @DisplayName("정적 of 메서드로 User 객체를 생성하고 초기 상태를 확인한다")
+    void createOf_success() {
+        // given
+        UserRole testRole = UserRole.INSTRUCTOR;
+        UserStatus testUserStatus = UserStatus.ACTIVE;
+
+        // when
+        User user = User.of(userId, initialName, userEmail, testRole, testUserStatus);
+
+        // then
+        assertAll(
+            () -> assertEquals(testRole, user.role(), "전달된 역할과 일치해야 한다."),
+            () -> assertEquals(UserStatus.ACTIVE, user.userStatus(), "상태는 ACTIVE여야 한다.")
+        );
+    }
+
+    // --- 2. 상태 변경 메서드 테스트 ---
+
+    @Test
+    @DisplayName("updateName: 사용자 이름을 성공적으로 업데이트한다")
+    void updateName_success() {
+        User learner = User.createLearner(userId, initialName, userEmail);
+        UserName newName = new UserName("test2");
+
+        // when
+        learner.updateName(newName);
+
+        // then
+        assertEquals(newName.value(), learner.name(), "이름이 새 이름으로 업데이트되어야 한다.");
+    }
+
+    @Test
+    @DisplayName("makeInstructor: ACTIVE인 LEARNER는 INSTRUCTOR로 승급된다")
+    void makeInstructor_fromLearnerToInstructor() {
+        // given
+        User learner = User.createLearner(userId, initialName, userEmail);
+        assertEquals(UserRole.LEARNER, learner.role());
+
+        // when
+        learner.makeInstructor();
+
+        // then
+        assertEquals(UserRole.INSTRUCTOR, learner.role(), "역할이 INSTRUCTOR로 변경되어야 한다.");
+    }
+
+    @Test
+    @DisplayName("makeInstructor: 이미 INSTRUCTOR인 경우 역할은 변하지 않는다")
+    void makeInstructor_alreadyInstructor() {
+        // given
+        User instructor = User.createInstructor(userId, initialName, userEmail);
+        assertEquals(UserRole.INSTRUCTOR, instructor.role());
+
+        // when
+        instructor.makeInstructor();
+
+        // then
+        assertEquals(UserRole.INSTRUCTOR, instructor.role(), "역할은 여전히 INSTRUCTOR여야 한다.");
+    }
+
+    @Test
+    @DisplayName("makeInstructor: DELETED 상태인 LEARNER는 INSTRUCTOR로 승급되지 않는다")
+    void makeInstructor_deletedUserCannotBePromoted() {
+        // given
+        User learner = User.createLearner(userId, initialName, userEmail);
+        learner.withdraw(); // DELETED 상태로 변경
+        assertEquals(UserStatus.DELETED, learner.userStatus());
+
+        // when
+        learner.makeInstructor();
+
+        // then
+        assertEquals(UserRole.LEARNER, learner.role(), "DELETED 상태이므로 역할은 LEARNER로 유지되어야 한다.");
+    }
+
+    @Test
+    @DisplayName("withdraw: 사용자 상태를 DELETED로 변경한다")
+    void withdraw_success() {
+        // Given
+        User learner = User.createLearner(userId, initialName, userEmail);
+        assertEquals(UserStatus.ACTIVE, learner.userStatus());
+
+        // When
+        learner.withdraw();
+
+        // Then
+        assertEquals(UserStatus.DELETED, learner.userStatus(), "사용자 상태가 DELETED로 변경되어야 한다.");
+    }
+
+    // --- 3. 권한 확인 메서드 테스트 ---
+
+    @Test
+    @DisplayName("canManageOwnCourse: INSTRUCTOR는 자신의 코스를 관리할 수 있다")
+    void canManageOwnCourse_instructor() {
+        // given
+        User instructor = User.createInstructor(userId, initialName, userEmail);
+
+        // then
+        assertTrue(instructor.canManageOwnCourse(), "INSTRUCTOR는 코스를 관리할 수 있어야 한다.");
+    }
+
+    @Test
+    @DisplayName("canManageOwnCourse: ADMIN은 자신의 코스를 관리할 수 있다")
+    void canManageOwnCourse_admin() {
+        // given
+        User admin = User.createAdmin(userId, initialName, userEmail);
+
+        // then
+        assertTrue(admin.canManageOwnCourse(), "ADMIN은 코스를 관리할 수 있어야 한다.");
+    }
+
+    @Test
+    @DisplayName("canManageOwnCourse: LEARNER는 자신의 코스를 관리할 수 없다")
+    void canManageOwnCourse_learner() {
+        // given
+        User learner = User.createLearner(userId, initialName, userEmail);
+
+        // then
+        assertFalse(learner.canManageOwnCourse(), "LEARNER는 코스를 관리할 수 없어야 한다.");
+    }
+
+    @Test
+    @DisplayName("canManageAllCourses: ADMIN은 모든 코스를 관리할 수 있다")
+    void canManageAllCourses_admin() {
+        // given
+        User admin = User.createAdmin(userId, initialName, userEmail);
+
+        // then
+        assertTrue(admin.canManageAllCourses(), "ADMIN은 모든 코스를 관리할 수 있어야 한다.");
+    }
+
+    @Test
+    @DisplayName("canManageAllCourses: INSTRUCTOR는 모든 코스를 관리할 수 없다")
+    void canManageAllCourses_instructor() {
+        // given
+        User instructor = User.createInstructor(userId, initialName, userEmail);
+
+        // then
+        assertFalse(instructor.canManageAllCourses(), "INSTRUCTOR는 모든 코스를 관리할 수 없어야 한다.");
+    }
+
+    @Test
+    @DisplayName("canManageAllCourses: LEARNER는 모든 코스를 관리할 수 없다")
+    void canManageAllCourses_learner() {
+        // given
+        User learner = User.createLearner(userId, initialName, userEmail);
+
+        // then
+        assertFalse(learner.canManageAllCourses(), "LEARNER는 모든 코스를 관리할 수 없어야 한다.");
+    }
+
+}


### PR DESCRIPTION
## **PR 타이틀**

- Squash 시 최종 커밋 제목이 되므로 **Conventional Commits** 권장
    
    예) PR 제목 (#PR번호), `feat: support refresh token rotation (#1234)`

##  Summary
- 무엇/왜 (한 줄 요약)

##  Related Issue
- Issue Number: #<이슈번호>
- Closes #19 

##  Changes
- user와 auth 도메인 생성
- 기존 브랜치에서 develop을 rebase했으나 revert 커밋이 fix 커밋 뒤에 배치되는 상황이 벌어져 브랜치 교체합니다.
- 위의 상황으로 인해 기존에 커밋됐던 일부 파일들이 브랜치 내에 뜨지 않는 이슈가 발생하였습니다.
- `dnya0/feat/user-domain` 브랜치는 pr 머지 이후 삭제 예정입니다.

<img width="740" height="221" alt="스크린샷 2025-12-08 오전 2 05 51" src="https://github.com/user-attachments/assets/ae9d7c81-3b80-4f4c-ad4e-040d41536a57" />

##  Discussion Topic
- 의논하고싶은 주제

##  Checklist
- [x] 로컬 테스트 완료
- [x] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [x] 브랜치 최신화(rebase) 및 충돌 없음
