### PR TITLE
feat(tag): port and implementation for external use

### DIFF
--- a/tag/build.gradle
+++ b/tag/build.gradle
@@ -21,7 +21,9 @@ bootJar {
 }
 
 dependencies {
-
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation project(':common')
 }
 
 tasks.named('test') {

--- a/tag/src/main/java/com/lxp/tag/application/port/provided/dto/CategoryResult.java
+++ b/tag/src/main/java/com/lxp/tag/application/port/provided/dto/CategoryResult.java
@@ -1,0 +1,11 @@
+package com.lxp.tag.application.port.provided.dto;
+
+import java.util.List;
+
+public record CategoryResult(
+        long tagCategoryId,
+        String name,
+        String state, // ACTIVE, INACTIVE
+        List<TagResult> tags
+) {
+}

--- a/tag/src/main/java/com/lxp/tag/application/port/provided/dto/TagResult.java
+++ b/tag/src/main/java/com/lxp/tag/application/port/provided/dto/TagResult.java
@@ -1,0 +1,10 @@
+package com.lxp.tag.application.port.provided.dto;
+
+public record TagResult(
+        long tagId,
+        String name,
+        String state, // ACTIVE, INACTIVE
+        String color,
+        String variant
+) {
+}

--- a/tag/src/main/java/com/lxp/tag/application/port/provided/external/ExternalFindTagPort.java
+++ b/tag/src/main/java/com/lxp/tag/application/port/provided/external/ExternalFindTagPort.java
@@ -1,0 +1,12 @@
+package com.lxp.tag.application.port.provided.external;
+
+import com.lxp.tag.application.port.provided.dto.TagResult;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ExternalFindTagPort {
+    List<TagResult> findByIds(List<Long> ids);
+    Optional<TagResult> findById(Long id);
+    Optional<TagResult> findIdByName(String name);
+}

--- a/tag/src/main/java/com/lxp/tag/application/port/provided/usecase/FindCategoryUseCase.java
+++ b/tag/src/main/java/com/lxp/tag/application/port/provided/usecase/FindCategoryUseCase.java
@@ -1,6 +1,6 @@
 package com.lxp.tag.application.port.provided.usecase;
 
-import com.lxp.tag.application.port.provided.dto.CategoryResult;
+import com.lxp.tag.application.port.query.CategoryResult;
 
 import java.util.List;
 

--- a/tag/src/main/java/com/lxp/tag/application/port/provided/usecase/FindCategoryUseCase.java
+++ b/tag/src/main/java/com/lxp/tag/application/port/provided/usecase/FindCategoryUseCase.java
@@ -1,0 +1,9 @@
+package com.lxp.tag.application.port.provided.usecase;
+
+import com.lxp.tag.application.port.provided.dto.CategoryResult;
+
+import java.util.List;
+
+public interface FindCategoryUseCase {
+    List<CategoryResult> findAll();
+}

--- a/tag/src/main/java/com/lxp/tag/application/port/query/CategoryResult.java
+++ b/tag/src/main/java/com/lxp/tag/application/port/query/CategoryResult.java
@@ -1,4 +1,4 @@
-package com.lxp.tag.application.port.provided.dto;
+package com.lxp.tag.application.port.query;
 
 import java.util.List;
 

--- a/tag/src/main/java/com/lxp/tag/application/port/query/TagResult.java
+++ b/tag/src/main/java/com/lxp/tag/application/port/query/TagResult.java
@@ -1,4 +1,4 @@
-package com.lxp.tag.application.port.provided.dto;
+package com.lxp.tag.application.port.query;
 
 public record TagResult(
         long tagId,

--- a/tag/src/main/java/com/lxp/tag/application/port/required/TagCategoryQueryPort.java
+++ b/tag/src/main/java/com/lxp/tag/application/port/required/TagCategoryQueryPort.java
@@ -1,0 +1,9 @@
+package com.lxp.tag.application.port.required;
+
+import com.lxp.tag.application.port.query.CategoryResult;
+
+import java.util.List;
+
+public interface TagCategoryQueryPort {
+    List<CategoryResult> findAllWithTags();
+}

--- a/tag/src/main/java/com/lxp/tag/application/port/required/TagQueryPort.java
+++ b/tag/src/main/java/com/lxp/tag/application/port/required/TagQueryPort.java
@@ -1,11 +1,11 @@
-package com.lxp.tag.application.port.provided.external;
+package com.lxp.tag.application.port.required;
 
 import com.lxp.tag.application.port.query.TagResult;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface ExternalFindTagPort {
+public interface TagQueryPort {
     List<TagResult> findByIds(List<Long> ids);
     Optional<TagResult> findById(Long id);
     Optional<TagResult> findIdByName(String name);

--- a/tag/src/main/java/com/lxp/tag/application/service/ExternalFindTagService.java
+++ b/tag/src/main/java/com/lxp/tag/application/service/ExternalFindTagService.java
@@ -1,0 +1,31 @@
+package com.lxp.tag.application.service;
+
+import com.lxp.tag.application.port.provided.external.ExternalFindTagPort;
+import com.lxp.tag.application.port.query.TagResult;
+import com.lxp.tag.infrastructure.external.TagQueryAdapter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ExternalFindTagService implements ExternalFindTagPort {
+    private final TagQueryAdapter tagQueryAdapter;
+
+    @Override
+    public List<TagResult> findByIds(List<Long> ids) {
+        return tagQueryAdapter.findByIds(ids);
+    }
+
+    @Override
+    public Optional<TagResult> findById(Long id) {
+        return tagQueryAdapter.findById(id);
+    }
+
+    @Override
+    public Optional<TagResult> findIdByName(String name) {
+        return tagQueryAdapter.findIdByName(name);
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/application/service/TagCategoryQueryService.java
+++ b/tag/src/main/java/com/lxp/tag/application/service/TagCategoryQueryService.java
@@ -1,0 +1,20 @@
+package com.lxp.tag.application.service;
+
+import com.lxp.tag.application.port.provided.usecase.FindCategoryUseCase;
+import com.lxp.tag.application.port.query.CategoryResult;
+import com.lxp.tag.application.port.required.TagCategoryQueryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TagCategoryQueryService implements FindCategoryUseCase {
+    private final TagCategoryQueryPort tagCategoryQueryPort;
+
+    @Override
+    public List<CategoryResult> findAll() {
+        return tagCategoryQueryPort.findAllWithTags();
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/infrastructure/external/TagCategoryQueryAdapter.java
+++ b/tag/src/main/java/com/lxp/tag/infrastructure/external/TagCategoryQueryAdapter.java
@@ -1,0 +1,23 @@
+package com.lxp.tag.infrastructure.external;
+
+import com.lxp.tag.application.port.query.CategoryResult;
+import com.lxp.tag.application.port.required.TagCategoryQueryPort;
+import com.lxp.tag.infrastructure.persistence.jpa.TagCategoryJpaRepository;
+import com.lxp.tag.infrastructure.persistence.jpa.entity.TagCategoryJpaEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class TagCategoryQueryAdapter implements TagCategoryQueryPort {
+    private final TagCategoryJpaRepository tagCategoryJpaRepository;
+
+    @Override
+    public List<CategoryResult> findAllWithTags() {
+        return tagCategoryJpaRepository.findAllWithTags()
+                .stream().map(TagCategoryJpaEntity::toResult)
+                .toList();
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/infrastructure/external/TagQueryAdapter.java
+++ b/tag/src/main/java/com/lxp/tag/infrastructure/external/TagQueryAdapter.java
@@ -1,0 +1,34 @@
+package com.lxp.tag.infrastructure.external;
+
+import com.lxp.tag.application.port.query.TagResult;
+import com.lxp.tag.application.port.required.TagQueryPort;
+import com.lxp.tag.infrastructure.persistence.jpa.TagJpaRepository;
+import com.lxp.tag.infrastructure.persistence.jpa.entity.TagJpaEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class TagQueryAdapter implements TagQueryPort {
+    private final TagJpaRepository tagJpaRepository;
+
+    @Override
+    public List<TagResult> findByIds(List<Long> ids) {
+        return tagJpaRepository.findByIdIn(ids)
+                .stream().map(TagJpaEntity::toResult)
+                .toList();
+    }
+
+    @Override
+    public Optional<TagResult> findById(Long id) {
+        return tagJpaRepository.findById(id).map(TagJpaEntity::toResult);
+    }
+
+    @Override
+    public Optional<TagResult> findIdByName(String name) {
+        return tagJpaRepository.findByName(name).map(TagJpaEntity::toResult);
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/infrastructure/persistence/jpa/TagCategoryJpaRepository.java
+++ b/tag/src/main/java/com/lxp/tag/infrastructure/persistence/jpa/TagCategoryJpaRepository.java
@@ -1,0 +1,18 @@
+package com.lxp.tag.infrastructure.persistence.jpa;
+
+import com.lxp.tag.infrastructure.persistence.jpa.entity.TagCategoryJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TagCategoryJpaRepository extends JpaRepository<TagCategoryJpaEntity, Long> {
+    @Query("""
+        select distinct c
+        from TagCategoryJpaEntity c
+        left join fetch c.tags
+    """)
+    List<TagCategoryJpaEntity> findAllWithTags();
+}

--- a/tag/src/main/java/com/lxp/tag/infrastructure/persistence/jpa/TagJpaRepository.java
+++ b/tag/src/main/java/com/lxp/tag/infrastructure/persistence/jpa/TagJpaRepository.java
@@ -1,0 +1,22 @@
+package com.lxp.tag.infrastructure.persistence.jpa;
+
+import com.lxp.tag.infrastructure.persistence.jpa.entity.TagJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TagJpaRepository extends JpaRepository<TagJpaEntity, Long> {
+    List<TagJpaEntity> findByIdIn(List<Long> ids);
+
+    Optional<TagJpaEntity> findByName(String tagName);
+
+    @Query("""
+        select t.id
+        from TagJpaEntity t
+        where t.name = :name
+    """)
+    Optional<Long> findIdByName(@Param("name") String name);
+}

--- a/tag/src/main/java/com/lxp/tag/infrastructure/persistence/jpa/entity/TagCategoryJpaEntity.java
+++ b/tag/src/main/java/com/lxp/tag/infrastructure/persistence/jpa/entity/TagCategoryJpaEntity.java
@@ -1,0 +1,42 @@
+package com.lxp.tag.infrastructure.persistence.jpa.entity;
+
+import com.lxp.tag.application.port.query.CategoryResult;
+import com.lxp.tag.infrastructure.persistence.jpa.enums.TagState;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "tag_category")
+@NoArgsConstructor
+public class TagCategoryJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TagState state;
+
+    @OneToMany(
+            mappedBy = "category",
+            cascade = CascadeType.ALL
+    )
+    private List<TagJpaEntity> tags = new ArrayList<>();
+
+    public static CategoryResult toResult(TagCategoryJpaEntity entity) {
+        return new CategoryResult(
+                entity.id,
+                entity.name,
+                entity.state.toString(),
+                entity.tags.stream().map(TagJpaEntity::toResult).toList()
+        );
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/infrastructure/persistence/jpa/entity/TagJpaEntity.java
+++ b/tag/src/main/java/com/lxp/tag/infrastructure/persistence/jpa/entity/TagJpaEntity.java
@@ -1,0 +1,45 @@
+package com.lxp.tag.infrastructure.persistence.jpa.entity;
+
+import com.lxp.tag.application.port.query.TagResult;
+import com.lxp.tag.infrastructure.persistence.jpa.enums.TagState;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "tag")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TagJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false, length = 30)
+    private String color;
+
+    @Column(nullable = false, length = 30)
+    private String variant;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TagState state;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category", nullable = false)
+    private TagCategoryJpaEntity category;
+
+    public static TagResult toResult(TagJpaEntity entity) {
+        return new TagResult(
+                entity.id,
+                entity.name,
+                entity.state.toString(),
+                entity.color,
+                entity.variant
+        );
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/infrastructure/persistence/jpa/enums/TagCategoryState.java
+++ b/tag/src/main/java/com/lxp/tag/infrastructure/persistence/jpa/enums/TagCategoryState.java
@@ -1,0 +1,5 @@
+package com.lxp.tag.infrastructure.persistence.jpa.enums;
+
+public enum TagCategoryState {
+    ACTIVE, INACTIVE
+}

--- a/tag/src/main/java/com/lxp/tag/infrastructure/persistence/jpa/enums/TagState.java
+++ b/tag/src/main/java/com/lxp/tag/infrastructure/persistence/jpa/enums/TagState.java
@@ -1,0 +1,5 @@
+package com.lxp.tag.infrastructure.persistence.jpa.enums;
+
+public enum TagState {
+    ACTIVE, INACTIVE
+}

--- a/tag/src/main/java/com/lxp/tag/presentation/web/TagCategoryQueryController.java
+++ b/tag/src/main/java/com/lxp/tag/presentation/web/TagCategoryQueryController.java
@@ -1,0 +1,26 @@
+package com.lxp.tag.presentation.web;
+
+import com.lxp.tag.application.port.provided.usecase.FindCategoryUseCase;
+import com.lxp.tag.presentation.web.dto.TagCategoryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/tags")
+@RequiredArgsConstructor
+public class TagCategoryQueryController {
+    private final FindCategoryUseCase findCategoryUseCase;
+
+    @GetMapping
+    public ResponseEntity<List<TagCategoryResponse>> getAllCategories() {
+        List<TagCategoryResponse> responses = findCategoryUseCase.findAll()
+                .stream().map(TagCategoryResponse::from)
+                .toList();
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/presentation/web/dto/TagCategoryResponse.java
+++ b/tag/src/main/java/com/lxp/tag/presentation/web/dto/TagCategoryResponse.java
@@ -1,0 +1,21 @@
+package com.lxp.tag.presentation.web.dto;
+
+import com.lxp.tag.application.port.query.CategoryResult;
+
+import java.util.List;
+
+public record TagCategoryResponse(
+        long tagCategoryId,
+        String name,
+        String state,
+        List<TagResponse> tags
+) {
+    public static TagCategoryResponse from(CategoryResult result) {
+        return new TagCategoryResponse(
+                result.tagCategoryId(),
+                result.name(),
+                result.state(),
+                result.tags().stream().map(TagResponse::from).toList()
+        );
+    }
+}

--- a/tag/src/main/java/com/lxp/tag/presentation/web/dto/TagResponse.java
+++ b/tag/src/main/java/com/lxp/tag/presentation/web/dto/TagResponse.java
@@ -1,0 +1,21 @@
+package com.lxp.tag.presentation.web.dto;
+
+import com.lxp.tag.application.port.query.TagResult;
+
+public record TagResponse(
+        long tagId,
+        String content,
+        String state,
+        String color,
+        String variant
+) {
+    public static TagResponse from(TagResult result) {
+        return new TagResponse(
+                result.tagId(),
+                result.name(),
+                result.state(),
+                result.color(),
+                result.variant()
+        );
+    }
+}


### PR DESCRIPTION
##  Changes
- 다른 BC에서 사용될 provided 포트
- FE 에서 API로 호출해서 사용되는 포트

##  Discussion Topic
- 다른 BC (ex: content, user) 에서는 `ExternalFindTagPort`를 사용하시면 됩니다.
- 아직 테스트 코드 작성되지 않았습니다.
- 현재 JPA로 구현해 두었는데 해당 PR merge 이후 Redis 고려해서 구현해 보겠습니다.

##  Checklist
- [ ] 로컬 테스트 완료
- [ ] lint 통과(로컬)
- [ ] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [ ] 브랜치 최신화(rebase) 및 충돌 없음
