### PR TITLE
hotfix(application): modulith error fix

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
     implementation 'org.springframework.modulith:spring-modulith-starter-jpa:2.0.0'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
     implementation 'io.swagger.parser.v3:swagger-parser:2.1.22'
 
     implementation 'javax.xml.bind:jaxb-api:2.3.1'  // Java 9+ 환경에서 누락된 JAXB (javax.xml.bind.*) API 제공

--- a/application/src/main/java/com/lxp/MainApplication.java
+++ b/application/src/main/java/com/lxp/MainApplication.java
@@ -1,8 +1,7 @@
-package com.lxp.application;
+package com.lxp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 public class MainApplication {

--- a/application/src/main/java/com/lxp/application/RetryConfig.java
+++ b/application/src/main/java/com/lxp/application/RetryConfig.java
@@ -1,0 +1,29 @@
+package com.lxp.application;
+
+import com.lxp.common.retry.RetryPolicy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RetryConfig {
+
+    @Bean
+    public RetryPolicy retryPolicy() {
+        return new RetryPolicy() {
+            @Override
+            public int getMaxAttempts() {
+                return 1;
+            }
+
+            @Override
+            public long getBackoffMillis(int attempt) {
+                return 0L;
+            }
+
+            @Override
+            public boolean shouldRetry(Exception e) {
+                return false;
+            }
+        };
+    }
+}

--- a/application/src/test/java/com/lxp/ApplicationModuleTests.java
+++ b/application/src/test/java/com/lxp/ApplicationModuleTests.java
@@ -1,8 +1,7 @@
-package com.lxp.application;
+package com.lxp;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.modulith.core.ApplicationModules;
 import org.springframework.modulith.docs.Documenter;
 
@@ -13,10 +12,9 @@ class ApplicationModuleTests {
      * 프로젝트의 모듈 구조가 Modulith 규칙을 준수하는지 검증합니다.
      */
     @Test
-    void verifyModularity() {
-        // ApplicationModules.of(Class<?>): Modulith가 컨텍스트에서 모듈을 찾기 시작하는 시작점을 지정합니다.
-        // 여기서는 auth 모듈의 설정 클래스를 사용하지만, 어떤 도메인 모듈의 설정 클래스를 사용해도 무방합니다.
-        ApplicationModules.of(MainApplication.class).verify();
+    void verifyModularStructure() {
+        ApplicationModules modules = ApplicationModules.of("com.lxp");
+        modules.verify();
     }
 
     /**

--- a/common/src/main/java/com/lxp/common/package-info.java
+++ b/common/src/main/java/com/lxp/common/package-info.java
@@ -1,0 +1,4 @@
+@ApplicationModule(type = ApplicationModule.Type.OPEN)
+package com.lxp.common;
+
+import org.springframework.modulith.ApplicationModule;

--- a/user/src/main/resources/openapi-user.yml
+++ b/user/src/main/resources/openapi-user.yml
@@ -139,7 +139,8 @@ paths:
               properties:
                 role:
                   type: string
-                  description: "변경하고자 하는 새로운 역할 (예: INSTRUCTOR)"
+                  description:
+                    변경하고자 하는 새로운 역할 (예: "INSTRUCTOR")
                   enum: [ "LEARNER", "INSTRUCTOR" ]
       responses:
         '200':

--- a/user/src/main/resources/openapi-user.yml
+++ b/user/src/main/resources/openapi-user.yml
@@ -139,8 +139,7 @@ paths:
               properties:
                 role:
                   type: string
-                  description:
-                    변경하고자 하는 새로운 역할 (예: "INSTRUCTOR")
+                  description: "변경하고자 하는 새로운 역할 (예: INSTRUCTOR)"
                   enum: [ "LEARNER", "INSTRUCTOR" ]
       responses:
         '200':


### PR DESCRIPTION
##  Changes
- springdoc-openapi 2.5.0 버전이 spring boot 4.0.0 버전과 맞지 않아 NoSuchMethodError가 발생. springdoc-openapi 3.0.0으로 변경
- MainApplication가 패키지 com.lxp.application 에 위치해 있었습니다. 다른 모듈은 com.lxp 하위에 정의되어 있어 컴포넌트 스캔이 제대로 이뤄지지 않고 있었습니다. MainApplicaton 위치가 com.lxp로 변경되었습니다.
- RetryConfig를 구현하는 빈이 없어서 컴포넌트 스캔시 에러가 발생했습니다. 임시로 RetryConfig를 구현해 추가해 두었습니다. 
- ApplicationModuleTests 테스트시 com.lxp 를 기준으로 확인할 수 있게 코드를 수정했습니다.
- ApplicationModuleTests 결과 다른 모듈들이 common을 의존하고 있습니다. common이 public하게 다른 모듈에서 사용할 수 있음을  명시해야 해서 package-info.java가 추가되었습니다.
- 터미널에서 아래 사진과 같은 경고가 발생해서 임시로 openapi-user.yml 파일 수정해 두었습니다 
<img width="1223" height="429" alt="image" src="https://github.com/user-attachments/assets/b9a9c915-9f7e-48e2-b8f2-e3a316161a2a" />

##  Discussion Topic
- 더 좋은 방법이 있거나 잘 못된 방향이 있다면 말씀 부탁드립니다

##  Checklist
- [x] 로컬 테스트 완료
- [x] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [x] 브랜치 최신화(rebase) 및 충돌 없음
