### PR TITLE
feat(auth): implement custom error handling for authentication and access denial

### DIFF
--- a/auth/src/main/java/com/lxp/auth/infrastructure/security/config/SecurityConfig.java
+++ b/auth/src/main/java/com/lxp/auth/infrastructure/security/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                     "/swagger-ui/**",
                     "/swagger-ui.html",
                     "/swagger-resources/**").permitAll()
-                .requestMatchers("/api-v1/auth/login", "/api-v1/auth/register").permitAll()
+                .requestMatchers("/api-v1/auth/login", "/api-v1/auth/register", "/api-v1/error/**").permitAll()
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/auth/src/main/java/com/lxp/auth/infrastructure/security/handler/CustomAccessDeniedHandler.java
+++ b/auth/src/main/java/com/lxp/auth/infrastructure/security/handler/CustomAccessDeniedHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.WebAttributes;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
@@ -19,10 +20,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        String jsonResponse = String.format(
-            "{\"status\": 403, \"message\": \"Access Denied. You do not have sufficient permissions to access this resource.\", \"error\": \"%s\"}",
-            accessDeniedException.getMessage()
-        );
-        response.getWriter().write(jsonResponse);
+        request.setAttribute(WebAttributes.ACCESS_DENIED_403, accessDeniedException);
+        request.getRequestDispatcher("/api-v1/error/access-denied").forward(request, response);
     }
 }

--- a/auth/src/main/java/com/lxp/auth/infrastructure/security/handler/CustomAuthenticationEntryPoint.java
+++ b/auth/src/main/java/com/lxp/auth/infrastructure/security/handler/CustomAuthenticationEntryPoint.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.WebAttributes;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -17,6 +18,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.getWriter().write("{\"status\": 401, \"message\": \"Authentication failed. Please check your token.\"}");
+        request.setAttribute(WebAttributes.AUTHENTICATION_EXCEPTION, authException);
+        request.getRequestDispatcher("/api-v1/error/authentication-failed").forward(request, response);
     }
 }

--- a/auth/src/main/java/com/lxp/auth/presentation/rest/common/AuthenticationErrorController.java
+++ b/auth/src/main/java/com/lxp/auth/presentation/rest/common/AuthenticationErrorController.java
@@ -1,0 +1,39 @@
+package com.lxp.auth.presentation.rest.common;
+
+import com.lxp.auth.domain.common.exception.AuthErrorCode;
+import com.lxp.auth.domain.common.exception.AuthException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.WebAttributes;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api-v1/error")
+public class AuthenticationErrorController {
+
+    @GetMapping("/access-denied")
+    public void accessDenied(HttpServletRequest request) {
+        AccessDeniedException originalException =
+            (AccessDeniedException) request.getAttribute(WebAttributes.ACCESS_DENIED_403);
+
+        String message = (originalException != null)
+            ? originalException.getMessage() : "권한이 없는 접근입니다.";
+
+        throw new AuthException(AuthErrorCode.ACCESS_DENIED, message);
+    }
+
+    @GetMapping("/authentication-failed")
+    public void authenticationFailed(HttpServletRequest request) {
+        AuthenticationException originalException =
+            (AuthenticationException) request.getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION);
+
+        String message = (originalException != null)
+            ? originalException.getMessage() : "인증에 실패했습니다. 토큰을 확인해주세요.";
+
+        throw new AuthException(AuthErrorCode.UNAUTHORIZED_ACCESS, message);
+    }
+
+}


### PR DESCRIPTION
## **PR 타이틀**

- Squash 시 최종 커밋 제목이 되므로 **Conventional Commits** 권장
    
    예) PR 제목 (#PR번호), `feat: support refresh token rotation (#1234)`

##  Summary
- filter에서 발생되는 exception을 리다이렉트하여 커스텀 에러 컨트롤러로 보내는 로직입니다.
- Error response의 포맷을 맞추기 위해 구현하였습니다.

##  Related Issue
- Issue Number: #<이슈번호>
- (선택) Closes #<이슈번호>  ← 머지 시 자동 닫힘

##  Changes


##  Discussion Topic
- 의논하고싶은 주제

##  Checklist
- [x] 로컬 테스트 완료
- [x] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [x] 브랜치 최신화(rebase) 및 충돌 없음
